### PR TITLE
Deployment

### DIFF
--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - deployment #TODO change to main before merging
+      - main
     paths-ignore:
       - "helm/**"
   release:
@@ -43,7 +43,7 @@ jobs:
         run: sbt test
 
   deploy:
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/deployment' #TODO change to main before merging
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     needs: [ verify ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -3,9 +3,8 @@ name: Adopt Tapir CI
 on:
   pull_request:
   push:
-    tags: [v*]
     branches:
-      - main
+      - deployment #TODO change to main before merging
     paths-ignore:
       - "helm/**"
   release:
@@ -42,3 +41,38 @@ jobs:
       - name: Run tests
         id: run-tests
         run: sbt test
+
+  deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/deployment' #TODO change to main before merging
+    needs: [ verify ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check-out repository
+        id: repo-checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        id: jdk-setup
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache SBT
+        id: cache-sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish docker image
+        run: sbt backend/docker:publish

--- a/backend/src/main/resources/webapp/index.html
+++ b/backend/src/main/resources/webapp/index.html
@@ -1,0 +1,1 @@
+Hello, world

--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,8 @@ lazy val fatJarSettings = Seq(
   }
 )
 
+def versionWithTimestamp(version: String): String = s"$version-${System.currentTimeMillis()}"
+
 lazy val dockerSettings = Seq(
   dockerExposedPorts := Seq(8080),
   dockerBaseImage := "adoptopenjdk:11.0.5_10-jdk-hotspot",
@@ -130,7 +132,9 @@ lazy val dockerSettings = Seq(
   dockerUsername := Some("softwaremill"),
   dockerUpdateLatest := true,
   Docker / publishLocal := (Docker / publishLocal).value,
-  Docker / version := git.gitDescribedVersion.value.getOrElse(git.formattedShaVersion.value.getOrElse("latest")),
+  Docker / version := git.gitDescribedVersion.value
+    .map(versionWithTimestamp)
+    .getOrElse(git.formattedShaVersion.value.map(versionWithTimestamp).getOrElse("latest")),
   git.uncommittedSignifier := Some("dirty"),
   ThisBuild / git.formattedShaVersion := {
     val base = git.baseVersion.?.value


### PR DESCRIPTION
Adds a (very) basic `index.html` and a GitHub Action to publish an image to Docker Hub on every push to `main`.

The GCP deployment is set up in https://github.com/softwaremill/gcp-sml-internal-iac/tree/main/apps/base/adopt-tapir. Flux automatically picks the newest image from Docker Hub when it's published and deploys it to GCP.

The deployed webapp (from the `deployment` branch until the PR is merged) is available at https://adopt-tapir.softwaremill.com.

Closes #20.