### PR TITLE
imp(): make frontend app styling responsive

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -26,7 +26,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#55494b" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/ui/src/App.styles.ts
+++ b/ui/src/App.styles.ts
@@ -2,11 +2,28 @@ import { makeStyles } from 'tss-react/mui';
 import { darken } from '@mui/system/colorManipulator';
 
 export const useStyles = makeStyles()(theme => ({
+  gridContainer: {
+    height: '100vh',
+  },
+
   configurationWrapper: {
     height: '92%',
     backgroundColor: theme.palette.neutral.main,
-    padding: theme.spacing(8, 20),
+    padding: theme.spacing(8, 3),
+
+    [theme.breakpoints.up('sm')]: {
+      padding: theme.spacing(8, 10),
+    },
+
+    [theme.breakpoints.up('xl')]: {
+      padding: theme.spacing(8, 16),
+    },
   },
+
+  configurationPaper: {
+    padding: theme.spacing(3),
+  },
+
   footerWrapper: {
     height: '8%',
     backgroundColor: darken(theme.palette.neutral.main, 0.1),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,8 +1,9 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { CssBaseline, Grid, Paper, Box } from '@mui/material';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { CssBaseline, Grid, Paper, Box, Container, ThemeProvider } from '@mui/material';
 import { Sidebar } from 'components/Sidebar';
 import { ConfigurationForm } from 'components/ConfigurationForm';
 import { Footer } from 'components/Footer';
+import { embeddedTheme } from './theme';
 
 import { useStyles } from './App.styles';
 
@@ -18,16 +19,18 @@ export const App: React.FC = () => {
             <main>
               <CssBaseline />
 
-              <Grid container sx={{ height: '100vh' }}>
-                <Grid item xs={3}>
+              <Grid className={classes.gridContainer} container>
+                <Grid item xs={12} md={3}>
                   <Sidebar />
                 </Grid>
 
-                <Grid item xs={9}>
+                <Grid item xs={12} md={9}>
                   <Box className={classes.configurationWrapper}>
-                    <Paper variant="outlined" sx={{ padding: 3 }}>
-                      <ConfigurationForm />
-                    </Paper>
+                    <Container maxWidth="lg" disableGutters>
+                      <Paper className={classes.configurationPaper} variant="outlined">
+                        <ConfigurationForm />
+                      </Paper>
+                    </Container>
                   </Box>
                   <Box className={classes.footerWrapper}>
                     <Footer />
@@ -38,7 +41,17 @@ export const App: React.FC = () => {
           }
         />
 
-        <Route path="/embedded-form" element={<ConfigurationForm showHeader={false} />} />
+        <Route
+          path="/embedded-form"
+          element={
+            <ThemeProvider theme={embeddedTheme}>
+              <CssBaseline />
+              <ConfigurationForm isEmbedded />
+            </ThemeProvider>
+          }
+        />
+
+        <Route path="*" element={<Navigate to="/" replace={true} />} />
       </Routes>
     </BrowserRouter>
   );

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -23,15 +23,15 @@ import {
 } from './ConfigurationForm.helpers';
 
 interface ConfigurationFormProps {
-  showHeader?: boolean;
+  isEmbedded?: boolean;
 }
 
-export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ showHeader = true }) => {
+export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded = false }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const { isScalaVersionFieldVisible, isMetricsEndpointsFieldVisible } = useFeatureFlag();
 
-  const { classes, cx } = useStyles();
+  const { classes, cx } = useStyles({ isEmbedded });
   const form = useForm<StarterRequest>({
     mode: 'onBlur',
     resolver: yupResolver(createStarterValidationSchema(isScalaVersionFieldVisible, isMetricsEndpointsFieldVisible)),
@@ -109,7 +109,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ showHeader
 
   return (
     <Box>
-      {showHeader && (
+      {!isEmbedded && (
         <Typography variant="h3" component="h3" fontWeight={300} gutterBottom>
           Generate tapir project
         </Typography>
@@ -187,7 +187,14 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ showHeader
               Reset
             </Button>
 
-            <Button variant="contained" color="primary" size="medium" type="submit" disableElevation>
+            <Button
+              className={classes.submitButton}
+              variant="contained"
+              color="primary"
+              size="medium"
+              type="submit"
+              disableElevation
+            >
               Generate .zip
             </Button>
           </div>

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.styles.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.styles.ts
@@ -1,38 +1,65 @@
 import { makeStyles } from 'tss-react/mui';
 
-export const useStyles = makeStyles()(theme => ({
-  formContainer: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    columnGap: theme.spacing(3),
-    rowGap: theme.spacing(0.5),
-  },
-  formMetadataRow: {
-    gridRowStart: 1,
-  },
-  formVersionsRow: {
-    gridRowStart: 2,
-  },
-  formEffectsRow: {
-    gridRowStart: 3,
-  },
-  formEndpointsRow: {
-    gridRowStart: 4,
-  },
-  formEndpoints2ndRow: {
-    gridRowStart: 5,
-  },
-  formActionsRow: {
-    gridColumnStart: 2,
-    gridColumnEnd: 3,
-    gridRowStart: 6,
-  },
-  actionsContainer: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    '& button:first-child': {
-      marginRight: theme.spacing(2),
+export const useStyles = makeStyles<{ isEmbedded: boolean }>()((theme, { isEmbedded }) => {
+  // NOTE: if the form container is embedded we use different breakpoint for 2 columns variant
+  const breakpoint = isEmbedded ? 500 : 'lg';
+
+  return {
+    formContainer: {
+      display: 'grid',
+      gridTemplateColumns: '1fr',
+      columnGap: theme.spacing(3),
+      rowGap: theme.spacing(0.5),
+
+      [theme.breakpoints.up(breakpoint)]: {
+        gridTemplateColumns: '1fr 1fr',
+      },
     },
-  },
-}));
+
+    formMetadataRow: {
+      [theme.breakpoints.up(breakpoint)]: {
+        gridRowStart: 1,
+      },
+    },
+    formVersionsRow: {
+      [theme.breakpoints.up(breakpoint)]: {
+        gridRowStart: 2,
+      },
+    },
+    formEffectsRow: {
+      [theme.breakpoints.up(breakpoint)]: {
+        gridRowStart: 3,
+      },
+    },
+    formEndpointsRow: {
+      [theme.breakpoints.up(breakpoint)]: {
+        gridRowStart: 4,
+      },
+    },
+    formEndpoints2ndRow: {
+      [theme.breakpoints.up(breakpoint)]: {
+        gridRowStart: 5,
+      },
+    },
+    formActionsRow: {
+      [theme.breakpoints.up(breakpoint)]: {
+        gridColumnStart: 2,
+        gridColumnEnd: 3,
+        gridRowStart: 6,
+      },
+    },
+
+    actionsContainer: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      '& button:first-child': {
+        marginRight: theme.spacing(2),
+      },
+    },
+
+    submitButton: {
+      whiteSpace: 'nowrap',
+    },
+  };
+});

--- a/ui/src/components/Sidebar/Sidebar.component.tsx
+++ b/ui/src/components/Sidebar/Sidebar.component.tsx
@@ -16,7 +16,7 @@ export const Sidebar = () => {
           </Typography>
         </figure>
 
-        <Typography className={classes.infoText} variant="subtitle1">
+        <Typography className={classes.infoText} variant="subtitle1" component="h1">
           Tapir provides a programmer-friendly, reasonably type-safe API to expose, consume and document HTTP endpoints,
           using the Scala language.
         </Typography>

--- a/ui/src/components/Sidebar/Sidebar.styles.ts
+++ b/ui/src/components/Sidebar/Sidebar.styles.ts
@@ -8,9 +8,12 @@ export const useStyles = makeStyles()(theme => ({
     alignItems: 'center',
     height: '100%',
     backgroundColor: theme.palette.secondary.main,
-    borderRightWidth: '2px',
-    borderRightStyle: 'solid',
-    borderRightColor: theme.palette.primary.main,
+
+    [theme.breakpoints.up('md')]: {
+      borderRightWidth: '2px',
+      borderRightStyle: 'solid',
+      borderRightColor: theme.palette.primary.main,
+    },
   },
 
   figureWrapper: {
@@ -26,9 +29,9 @@ export const useStyles = makeStyles()(theme => ({
   },
 
   figure: {
-    width: '50%',
+    width: '100%',
+    maxWidth: 260,
     marginTop: theme.spacing(8),
-    pointerEvents: 'none',
   },
 
   figcaption: {

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -1,6 +1,6 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme, responsiveFontSizes } from '@mui/material/styles';
 
-export const theme = createTheme({
+const baseTheme = createTheme({
   palette: {
     primary: {
       main: '#f3705e',
@@ -13,6 +13,16 @@ export const theme = createTheme({
     },
     neutral: {
       main: '#f5f5f5',
+    },
+  },
+});
+
+export const theme = responsiveFontSizes(baseTheme);
+
+export const embeddedTheme = createTheme(theme, {
+  palette: {
+    background: {
+      default: 'initial',
     },
   },
 });


### PR DESCRIPTION
Improved fronted app styling responsiveness to satisfy screens as low as 300px wide. Configuration form now accepts `isEmbedded` prop that will modify the behavior of form header and styling breakpoints. Improved a base theme to adjust font sizes based on the screen resolution.

# 320px
![320px](https://user-images.githubusercontent.com/24817919/173903430-19a48dda-59df-4f39-964b-7a6d30967be3.png)

# 425px
![425px](https://user-images.githubusercontent.com/24817919/173903433-3ca0e6eb-4e0c-4126-a9c6-0900ba94a3a9.png)

# 768px
![768px](https://user-images.githubusercontent.com/24817919/173903434-258abdf1-4fab-4709-ab89-9cf275502cb4.png)

# 1024px
![1024px](https://user-images.githubusercontent.com/24817919/173903436-5b7eabf1-f4f9-426d-afae-aa12719030ab.png)

# 1044px and above
![1440px](https://user-images.githubusercontent.com/24817919/173903438-3a03045e-83f9-4c40-bb2c-886b746c0ef6.png)

