### PR TITLE
Starter metrics

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/Dependencies.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/Dependencies.scala
@@ -7,8 +7,6 @@ import com.softwaremill.adopttapir.http.{Http, HttpApi, HttpConfig}
 import com.softwaremill.adopttapir.metrics.VersionApi
 import com.softwaremill.adopttapir.starter.api.StarterApi
 import com.softwaremill.macwire.autocats.autowire
-import io.prometheus.client.CollectorRegistry
-import io.prometheus.client.hotspot.DefaultExports
 import sttp.tapir.server.metrics.prometheus.PrometheusMetrics
 
 case class Dependencies(api: HttpApi)
@@ -23,9 +21,7 @@ object Dependencies {
         versionApi: VersionApi,
         cfg: HttpConfig
     ) = {
-      val registry = new CollectorRegistry()
-      DefaultExports.register(registry)
-      val prometheusMetrics = PrometheusMetrics.default[IO](registry = registry)
+      val prometheusMetrics = PrometheusMetrics.default[IO]("adopt_tapir")
       new HttpApi(
         http,
         userApi.endpoints,

--- a/backend/src/main/scala/com/softwaremill/adopttapir/Main.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/Main.scala
@@ -3,10 +3,12 @@ package com.softwaremill.adopttapir
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.softwaremill.adopttapir.config.Config
+import com.softwaremill.adopttapir.metrics.Metrics
 import com.typesafe.scalalogging.StrictLogging
 
 object Main extends StrictLogging {
   def main(args: Array[String]): Unit = {
+    Metrics.init()
     Thread.setDefaultUncaughtExceptionHandler((t, e) => logger.error("Uncaught exception in thread: " + t, e))
 
     val config = Config.read

--- a/backend/src/main/scala/com/softwaremill/adopttapir/metrics/Metrics.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/metrics/Metrics.scala
@@ -1,12 +1,25 @@
 package com.softwaremill.adopttapir.metrics
 
-import io.prometheus.client.Counter
+import com.softwaremill.adopttapir.starter.{JsonImplementation, ServerEffect, ServerImplementation, StarterDetails}
+import io.prometheus.client.{Counter, hotspot}
 
 object Metrics {
-  lazy val registeredUsersCounter: Counter =
+  lazy val generatedStarterCounter: Counter =
     Counter
       .build()
-      .name(s"adopttapir_registered_users_counter")
-      .help(s"How many users registered on this instance since it was started")
+      .name(s"adopt_tapir_starter_generated_total")
+      .labelNames(starterDetailsFieldNames: _*)
+      .help(
+        s"""Total generated starters with given parameters ${starterDetailsFieldNames.map(n => s"\"$n\"").mkString(", ")}"""
+      )
       .register()
+
+  def init(): Unit = hotspot.DefaultExports.initialize()
+
+  private val starterDetailsFieldNames: Array[String] = {
+    val fakeInstance: StarterDetails =
+      StarterDetails("", "", ServerEffect.IOEffect, ServerImplementation.Akka, "", true, JsonImplementation.WithoutJson)
+
+    fakeInstance.productElementNames.toArray
+  }
 }

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
@@ -5,10 +5,10 @@ import cats.effect.IO
 import cats.implicits.toBifunctorOps
 import com.softwaremill.adopttapir.Fail
 import com.softwaremill.adopttapir.http.Http
+import com.softwaremill.adopttapir.infrastructure.Json._
 import com.softwaremill.adopttapir.starter._
 import com.softwaremill.adopttapir.util.ServerEndpoints
 import fs2.io.file.Files
-import com.softwaremill.adopttapir.infrastructure.Json._
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.CodecFormat
 

--- a/development/http-client.env.json
+++ b/development/http-client.env.json
@@ -1,9 +1,9 @@
 {
   "dev": {
-    "url": "http://localhost:9090/api/v1"
+    "url": "http://localhost:9090/"
   },
   "prod": {
-    "url": "https://adopt-tapir.softwaremill.com/api/v1"
+    "url": "https://adopt-tapir.softwaremill.com/"
   }
 }
 

--- a/development/http-client.http
+++ b/development/http-client.http
@@ -1,4 +1,4 @@
-POST {{url}}/starter.zip
+POST {{url}}/api/v1/starter.zip
 Accept: application/zip
 Content-Type: application/json
 
@@ -11,5 +11,3 @@ Content-Type: application/json
   "addDocumentation": true,
   "json": "Jsoniter"
 }
-
-###


### PR DESCRIPTION
Example of an output: 

```
# HELP adopt_tapir_starter_generated_total Total generated starters with given parameters "projectName", "groupId", "serverEffect", "serverImplementation", "tapirVersion", "addDocumentation", "jsonImplementation"
# TYPE adopt_tapir_starter_generated_total counter
adopt_tapir_starter_generated_total{projectName="projectname",groupId="com.softwaremill",serverEffect="FutureEffect",serverImplementation="Akka",tapirVersion="1.0.0",addDocumentation="true",jsonImplementation="Jsoniter",} 1.0
```

closes #36 