### PR TITLE
chore: add metrics endpoint verification to endpoints spec

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
@@ -84,6 +84,7 @@ class ProjectTemplate(config: StarterConfig) {
 
     val helloServerStub = EndpointsSpecView.getHelloServerStub(starterDetails)
     val booksServerStub = EndpointsSpecView.getBookServerStub(starterDetails)
+    val metricsServerStup = EndpointsSpecView.getMetricsServerStub(starterDetails)
     val unwrapper = EndpointsSpecView.Unwrapper.prepareUnwrapper(starterDetails.serverEffect)
 
     val fileContent =
@@ -93,7 +94,8 @@ class ProjectTemplate(config: StarterConfig) {
             starterDetails,
             toSortedList(helloServerStub.imports ++ booksServerStub.imports),
             helloServerStub.body,
-            booksServerStub.body
+            booksServerStub.body,
+            metricsServerStup.body
           )
           .toString()
       else
@@ -103,7 +105,8 @@ class ProjectTemplate(config: StarterConfig) {
             toSortedList(helloServerStub.imports ++ booksServerStub.imports ++ unwrapper.imports),
             helloServerStub.body,
             unwrapper.body,
-            booksServerStub.body
+            booksServerStub.body,
+            metricsServerStup.body
           )
           .toString()
 

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.adopttapir.template.scala
 
 import com.softwaremill.adopttapir.starter.{JsonImplementation, ServerEffect, StarterDetails}
-import com.softwaremill.adopttapir.template.scala.EndpointsView.Constants.{booksListingServerEndpoint, helloServerEndpoint}
+import com.softwaremill.adopttapir.template.scala.EndpointsView.Constants.{booksListingServerEndpoint, helloServerEndpoint, metricsEndpoint}
 
 object EndpointsSpecView {
 
@@ -27,6 +27,10 @@ object EndpointsSpecView {
       case JsonImplementation.Jsoniter => stubBooks.addImports(Set(Import("sttp.client3.jsoniter._"), Import("Library._")))
       case JsonImplementation.ZIOJson  => stubBooks.addImports(Set(Import("sttp.client3.ziojson._"), Import("Library._")))
     }
+  }
+
+  def getMetricsServerStub(starterDetails: StarterDetails): Code = {
+    if (starterDetails.addMetrics)  Stub.prepareBackendStub(metricsEndpoint, starterDetails.serverEffect) else Code.empty
   }
 
   private object Stub {

--- a/backend/src/main/twirl/EndpointsSpec.scala.txt
+++ b/backend/src/main/twirl/EndpointsSpec.scala.txt
@@ -3,7 +3,8 @@ starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
 additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
 helloStub: String,
 unwrapper: String,
-booksStub: String
+booksStub: String,
+metricsStub: String
 )
 package @{starterDetails.groupId}
 import @{starterDetails.groupId}.Endpoints._
@@ -44,6 +45,29 @@ class EndpointsSpec extends AnyFlatSpec with Matchers with EitherValues{
 
     // then
     response.map(_.body.value shouldBe books.get()).unwrap
+  }
+}
+@if(metricsStub.nonEmpty){
+  it should "return metrics definition" in {
+    // given
+    @metricsStub
+
+    // when
+    val response = basicRequest
+      .get(uri"http://test.com/metrics")
+      .send(backendStub)
+
+    // then
+    response
+      .map(
+        _.body.value should (include ("# HELP tapir_request_duration_seconds Duration of HTTP requests")
+          and include("# TYPE tapir_request_duration_seconds histogram")
+          and include("# HELP tapir_request_total Total HTTP requests")
+          and include("# TYPE tapir_request_total counter")
+          and include("# HELP tapir_request_active Active HTTP requests")
+          and include("# TYPE tapir_request_active gauge"))
+      )
+      .unwrap
   }
 }
   @unwrapper

--- a/backend/src/main/twirl/EndpointsSpecZIO.scala.txt
+++ b/backend/src/main/twirl/EndpointsSpecZIO.scala.txt
@@ -2,7 +2,8 @@
 starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
 additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
 helloStub: String,
-booksStub: String
+booksStub: String,
+metricsStub: String
 )
 package @{starterDetails.groupId}
 import @{starterDetails.groupId}.Endpoints._
@@ -41,6 +42,29 @@ object EndpointsSpec extends ZIOSpecDefault {
 
       // then
       assertZIO(response.map(_.body))(isRight(equalTo(books.get())))
+    }
+}
+@if(metricsStub.nonEmpty){
+    ,test("return metrics definition") {
+      // given
+      @metricsStub
+
+      // when
+      val response = basicRequest
+        .get(uri"http://test.com/metrics")
+        .send(backendStub)
+
+      // then
+      assertZIO(response.map(_.body))(
+        isRight(
+          containsString("# HELP tapir_request_active Active HTTP requests")
+            && containsString("# TYPE tapir_request_duration_seconds histogram")
+            && containsString("# HELP tapir_request_total Total HTTP requests")
+            && containsString("# TYPE tapir_request_total counter")
+            && containsString("# HELP tapir_request_active Active HTTP requests")
+            && containsString("# TYPE tapir_request_active gauge")
+        )
+      )
     }
 }
   )


### PR DESCRIPTION
When 'addMetrics' is selected generate test that verifies if 'metrics'
endpoint is available. Apart from confirmation that metrics are enabled
it would give also an example on how to call it.

Closes #6