### PR TITLE
chore: add metrics endpoint verification to framework endpoints spec

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
@@ -35,7 +35,7 @@ class StarterService(
 
   }
 
-  private def generateFiles(starterDetails: StarterDetails): List[GeneratedFile] = {
+  protected def generateFiles(starterDetails: StarterDetails): List[GeneratedFile] = {
     List(
       template.getBuildSbt(starterDetails),
       template.getBuildProperties,

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
@@ -122,7 +122,7 @@ class ProjectTemplate(config: StarterConfig) {
   val README: GeneratedFile =
     GeneratedFile(readMeFile, templateResource(readMeFile))
 
-  private def pathUnderPackage(prefixDir: String, groupId: String, fileName: String): String =
+  protected def pathUnderPackage(prefixDir: String, groupId: String, fileName: String): String =
     prefixDir + "/" + groupId.split('.').mkString("/") + "/" + fileName
 
   private def templateResource(fileName: String): String = Resource.getAsString(s"template/$fileName")

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
@@ -29,7 +29,7 @@ object EndpointsSpecView {
     }
   }
 
-  private object Stub {
+  object Stub {
     def prepareBackendStub(endpoint: String, serverEffect: ServerEffect): Code = {
       val stub = serverEffect match {
         case ServerEffect.FutureEffect => "SttpBackendStub.asynchronousFuture"

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
@@ -4,13 +4,13 @@ import cats.effect.{ExitCode, IO, IOApp}
 import com.softwaremill.adopttapir.config.Config
 import com.softwaremill.adopttapir.starter.JsonImplementation.WithoutJson
 import com.softwaremill.adopttapir.starter.StarterDetails.defaultTapirVersion
-import com.softwaremill.adopttapir.template.ProjectTemplate
+import com.softwaremill.adopttapir.template.ProjectTemplateInTests
 
 @deprecated("Only for development purpose")
 object FileOperation extends IOApp {
 
   private val cfg = Config.read.starter
-  val service = new StarterService(cfg.copy(deleteTempFolder = false), new ProjectTemplate(cfg))
+  val service = new StarterServiceInTests(cfg.copy(deleteTempFolder = false), new ProjectTemplateInTests(cfg))
 
   override def run(args: List[String]): IO[ExitCode] = {
     val details = StarterDetails(
@@ -20,7 +20,7 @@ object FileOperation extends IOApp {
       ServerImplementation.ZIOHttp,
       defaultTapirVersion,
       true,
-      false,
+      true,
       WithoutJson
     )
 

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.softwaremill.adopttapir.starter.StarterDetails.defaultTapirVersion
 import com.softwaremill.adopttapir.starter.api._
-import com.softwaremill.adopttapir.template.ProjectTemplate
+import com.softwaremill.adopttapir.template.ProjectTemplateInTests
 import com.softwaremill.adopttapir.test.BaseTest
 import org.scalatest.ParallelTestExecution
 
@@ -31,7 +31,7 @@ class StarterServiceITTest extends BaseTest with ParallelTestExecution {
 
   private def createStarterService = {
     val config = StarterConfig(deleteTempFolder = true, tempPrefix = "sbtService", sbtVersion = "1.6.2", scalaVersion = "2.13.8")
-    new StarterService(config, new ProjectTemplate(config))
+    new StarterServiceInTests(config, new ProjectTemplateInTests(config))
   }
 
   private def sbtCompileTest(file: IO[File]): Unit = {

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceInTests.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceInTests.scala
@@ -1,0 +1,9 @@
+package com.softwaremill.adopttapir.starter
+
+import com.softwaremill.adopttapir.template.{GeneratedFile, ProjectTemplateInTests}
+
+class StarterServiceInTests(config: StarterConfig, template: ProjectTemplateInTests) extends StarterService(config, template) {
+  override protected def generateFiles(starterDetails: StarterDetails): List[GeneratedFile] =
+    super.generateFiles(starterDetails)
+      .appendedAll(if (starterDetails.addMetrics) List(template.getFrameworkEndpointsSpec(starterDetails)) else List())
+}

--- a/backend/src/test/scala/com/softwaremill/adopttapir/template/ProjectTemplateInTests.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/template/ProjectTemplateInTests.scala
@@ -1,0 +1,39 @@
+package com.softwaremill.adopttapir.template
+
+import com.softwaremill.adopttapir.starter.ServerEffect.ZIOEffect
+import com.softwaremill.adopttapir.starter.{StarterConfig, StarterDetails}
+import com.softwaremill.adopttapir.template.ProjectTemplate.toSortedList
+import com.softwaremill.adopttapir.template.scala.{EndpointsSpecView, FrameworkEndpointsSpecView}
+
+class ProjectTemplateInTests(config: StarterConfig) extends ProjectTemplate(config) {
+  def getFrameworkEndpointsSpec(starterDetails: StarterDetails): GeneratedFile = {
+    val groupId = starterDetails.groupId
+
+    val metricsServerStub = FrameworkEndpointsSpecView.getMetricsServerStub(starterDetails)
+
+    val fileContent =
+      if (starterDetails.serverEffect == ZIOEffect) {
+        txt
+          .FrameworkEndpointsSpecZIO(
+            starterDetails,
+            toSortedList(metricsServerStub.imports),
+            metricsServerStub.body
+          )
+      } else {
+        val unwrapper = EndpointsSpecView.Unwrapper.prepareUnwrapper(starterDetails.serverEffect)
+        txt
+          .FrameworkEndpointsSpec(
+            starterDetails,
+            toSortedList(metricsServerStub.imports ++ unwrapper.imports),
+            metricsServerStub.body,
+            unwrapper.body
+          )
+      }
+
+
+    GeneratedFile(
+      pathUnderPackage("src/test/scala", groupId, "FrameworkEndpointsSpec.scala"),
+      fileContent.toString
+    )
+  }
+}

--- a/backend/src/test/scala/com/softwaremill/adopttapir/template/scala/FrameworkEndpointsSpecView.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/template/scala/FrameworkEndpointsSpecView.scala
@@ -1,0 +1,11 @@
+package com.softwaremill.adopttapir.template.scala
+
+import com.softwaremill.adopttapir.starter.StarterDetails
+import com.softwaremill.adopttapir.template.scala.EndpointsSpecView.Stub
+import com.softwaremill.adopttapir.template.scala.EndpointsView.Constants.metricsEndpoint
+
+object FrameworkEndpointsSpecView {
+  def getMetricsServerStub(starterDetails: StarterDetails): Code = {
+    if (starterDetails.addMetrics) Stub.prepareBackendStub(metricsEndpoint, starterDetails.serverEffect) else Code.empty
+  }
+}

--- a/backend/src/test/twirl/FrameworkEndpointsSpec.scala.txt
+++ b/backend/src/test/twirl/FrameworkEndpointsSpec.scala.txt
@@ -1,0 +1,44 @@
+@(
+starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
+additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
+metricsStub: String,
+unwrapper: String,
+)
+package @{starterDetails.groupId}
+
+import @{starterDetails.groupId}.Endpoints._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client3.testing.SttpBackendStub
+import sttp.client3.{UriContext, basicRequest}
+import sttp.tapir.server.stub.TapirStubInterpreter
+@for(additionalImport <- additionalImports) {
+@{additionalImport.asScalaImport()}}
+
+class FrameworkEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues {
+@if(metricsStub.nonEmpty){
+  it should "return metrics definition" in {
+    // given
+    @metricsStub
+
+    // when
+    val response = basicRequest
+      .get(uri"http://test.com/metrics")
+      .send(backendStub)
+
+    // then
+    response
+      .map(
+        _.body.value should (include ("# HELP tapir_request_duration_seconds Duration of HTTP requests")
+          and include("# TYPE tapir_request_duration_seconds histogram")
+          and include("# HELP tapir_request_total Total HTTP requests")
+          and include("# TYPE tapir_request_total counter")
+          and include("# HELP tapir_request_active Active HTTP requests")
+          and include("# TYPE tapir_request_active gauge"))
+      )
+      .unwrap
+  }
+}
+  @unwrapper
+}

--- a/backend/src/test/twirl/FrameworkEndpointsSpecZIO.scala.txt
+++ b/backend/src/test/twirl/FrameworkEndpointsSpecZIO.scala.txt
@@ -1,0 +1,43 @@
+@(
+starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
+additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
+metricsStub: String
+)
+package @{starterDetails.groupId}
+
+import @{starterDetails.groupId}.Endpoints._
+import sttp.client3.testing.SttpBackendStub
+import sttp.client3.{UriContext, basicRequest}
+import sttp.tapir.server.stub.TapirStubInterpreter
+import zio.test.Assertion._
+import zio.test.{ZIOSpecDefault, assertZIO}
+@for(additionalImport <- additionalImports) {
+@{additionalImport.asScalaImport()}}
+
+object FrameworkEndpointsSpec extends ZIOSpecDefault {
+  def spec = suite("Framework Endpoints spec")(
+@if(metricsStub.nonEmpty){
+    test("return metrics definition") {
+      // given
+      @metricsStub
+
+      // when
+      val response = basicRequest
+        .get(uri"http://test.com/metrics")
+        .send(backendStub)
+
+      // then
+      assertZIO(response.map(_.body))(
+        isRight(
+          containsString("# HELP tapir_request_active Active HTTP requests")
+            && containsString("# TYPE tapir_request_duration_seconds histogram")
+            && containsString("# HELP tapir_request_total Total HTTP requests")
+            && containsString("# TYPE tapir_request_total counter")
+            && containsString("# HELP tapir_request_active Active HTTP requests")
+            && containsString("# TYPE tapir_request_active gauge")
+        )
+      )
+    }
+}
+  )
+}


### PR DESCRIPTION
When `addMetrics` is selected and `StarterServiceITTest` is called
generate `FrameworkEndpointsSpec.scala` that verifies if metrics
endpoint is available and returns expected result.
Note that the spec in question is only compiled for tests and doesn't
polute the generated production code.

For development purposes one can examine the spec by calling:
```
  com.softwaremill.adopttapir.starter.FileOperation
```
end examining their output.

Closes #6