### PR TITLE
chore: micro-organize EndpointsSpec.scala generation

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
@@ -84,10 +84,9 @@ class ProjectTemplate(config: StarterConfig) {
 
     val helloServerStub = EndpointsSpecView.getHelloServerStub(starterDetails)
     val booksServerStub = EndpointsSpecView.getBookServerStub(starterDetails)
-    val unwrapper = EndpointsSpecView.Unwrapper.prepareUnwrapper(starterDetails.serverEffect)
 
     val fileContent =
-      if (starterDetails.serverEffect == ZIOEffect)
+      if (starterDetails.serverEffect == ZIOEffect) {
         txt
           .EndpointsSpecZIO(
             starterDetails,
@@ -95,8 +94,8 @@ class ProjectTemplate(config: StarterConfig) {
             helloServerStub.body,
             booksServerStub.body
           )
-          .toString()
-      else
+      } else {
+        val unwrapper = EndpointsSpecView.Unwrapper.prepareUnwrapper(starterDetails.serverEffect)
         txt
           .EndpointsSpec(
             starterDetails,
@@ -105,11 +104,11 @@ class ProjectTemplate(config: StarterConfig) {
             unwrapper.body,
             booksServerStub.body
           )
-          .toString()
+      }
 
     GeneratedFile(
       pathUnderPackage("src/test/scala", groupId, "EndpointsSpec.scala"),
-      fileContent
+      fileContent.toString
     )
   }
 

--- a/backend/src/main/twirl/EndpointsSpec.scala.txt
+++ b/backend/src/main/twirl/EndpointsSpec.scala.txt
@@ -6,6 +6,7 @@ unwrapper: String,
 booksStub: String
 )
 package @{starterDetails.groupId}
+
 import @{starterDetails.groupId}.Endpoints._
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec

--- a/backend/src/main/twirl/EndpointsSpecZIO.scala.txt
+++ b/backend/src/main/twirl/EndpointsSpecZIO.scala.txt
@@ -5,6 +5,7 @@ helloStub: String,
 booksStub: String
 )
 package @{starterDetails.groupId}
+
 import @{starterDetails.groupId}.Endpoints._
 import sttp.client3.testing.SttpBackendStub
 import sttp.client3.{UriContext, basicRequest}


### PR DESCRIPTION
Changes:
* instatiate 'unwrapper' only when server effect is not ZIOEffect
* call 'toString' from one place (in `GenerateFile` constructor)
* add empty line package definition and import so that readability is
  improved in `EndpointsSpec[ZIO].scala.txt` templates