### PR TITLE
fix: information on how to terminate the running server

### DIFF
--- a/backend/src/main/twirl/MainFutureAkka.scala.txt
+++ b/backend/src/main/twirl/MainFutureAkka.scala.txt
@@ -28,7 +28,7 @@ object Main {
       .newServerAt("localhost", 8080)
       .bindFlow(route)
 
-    @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+    println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
     StdIn.readLine()
 
     bindingFuture.flatMap(_.unbind()).onComplete(_ => actorSystem.terminate())

--- a/backend/src/main/twirl/MainFutureNetty.scala.txt
+++ b/backend/src/main/twirl/MainFutureNetty.scala.txt
@@ -14,7 +14,7 @@ object Main {
     val program = for {
       binding <- NettyFutureServer().port(8080).addEndpoints(Endpoints.all).start()
       _ <- Future {
-        @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+        println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
         StdIn.readLine()
       }
       stop <- binding.stop()

--- a/backend/src/main/twirl/MainIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4s.scala.txt
@@ -26,7 +26,7 @@ object Main extends IOApp {
       .withHttpApp(Router("/" -> routes).orNotFound)
       .resource
       .use { _ => IO.blocking {
-         @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+         println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
          StdIn.readLine()
          }
       }

--- a/backend/src/main/twirl/MainIONetty.scala.txt
+++ b/backend/src/main/twirl/MainIONetty.scala.txt
@@ -19,7 +19,7 @@ object Main extends IOApp {
             .addEndpoints(Endpoints.all)
             .start()
           _ <- IO.blocking {
-            @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+            println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
             StdIn.readLine()
           }
           _ <- bind.stop()

--- a/backend/src/main/twirl/MainZIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4s.scala.txt
@@ -29,7 +29,7 @@ object Main extends ZIOAppDefault {
       .resource
       .use { _ =>
         ZIO.succeedBlocking{
-          @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+          println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
           StdIn.readLine()
         }
       }

--- a/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
@@ -22,7 +22,7 @@ object Main extends ZIOAppDefault {
 
     (for {
       serverStart <- Server(app).withPort(8080).make
-      _ <- Console.printLine(@if(addDocumentation){"Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit."}else{"Server started at http://localhost:8080. Press any key to exit."})
+      _ <- Console.printLine("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
       _ <- Console.readLine
     } yield serverStart)
       .provideSomeLayer(EventLoopGroup.auto(0) ++ ServerChannelFactory.auto ++ Scope.default)


### PR DESCRIPTION
When running server is started there is the following information
written:
```
  (...) Press any key to exit.
```
however pressing any key doesn't exit the server unless `ENTER` is
pressed. In fact pressing just `ENTER` works hence information was
modified to:
```
  (...) Press ENTER key to exit.
```