### PR TITLE
chore: add docs endpoint verification to framework endpoints spec

### DIFF
--- a/backend/src/main/twirl/MainFutureAkka.scala.txt
+++ b/backend/src/main/twirl/MainFutureAkka.scala.txt
@@ -28,7 +28,7 @@ object Main {
       .newServerAt("localhost", 8080)
       .bindFlow(route)
 
-    @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+    println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
     StdIn.readLine()
 
     bindingFuture.flatMap(_.unbind()).onComplete(_ => actorSystem.terminate())

--- a/backend/src/main/twirl/MainFutureNetty.scala.txt
+++ b/backend/src/main/twirl/MainFutureNetty.scala.txt
@@ -14,7 +14,7 @@ object Main {
     val program = for {
       binding <- NettyFutureServer().port(8080).addEndpoints(Endpoints.all).start()
       _ <- Future {
-        @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+        println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
         StdIn.readLine()
       }
       stop <- binding.stop()

--- a/backend/src/main/twirl/MainIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4s.scala.txt
@@ -26,7 +26,7 @@ object Main extends IOApp {
       .withHttpApp(Router("/" -> routes).orNotFound)
       .resource
       .use { _ => IO.blocking {
-         @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+         println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
          StdIn.readLine()
          }
       }

--- a/backend/src/main/twirl/MainIONetty.scala.txt
+++ b/backend/src/main/twirl/MainIONetty.scala.txt
@@ -19,7 +19,7 @@ object Main extends IOApp {
             .addEndpoints(Endpoints.all)
             .start()
           _ <- IO.blocking {
-            @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+            println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
             StdIn.readLine()
           }
           _ <- bind.stop()

--- a/backend/src/main/twirl/MainZIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4s.scala.txt
@@ -29,7 +29,7 @@ object Main extends ZIOAppDefault {
       .resource
       .use { _ =>
         ZIO.succeedBlocking{
-          @if(addDocumentation){println("Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit.")}else{println("Server started at http://localhost:8080. Press any key to exit.")}
+          println("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
           StdIn.readLine()
         }
       }

--- a/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
@@ -22,7 +22,7 @@ object Main extends ZIOAppDefault {
 
     (for {
       serverStart <- Server(app).withPort(8080).make
-      _ <- Console.printLine(@if(addDocumentation){"Go to http://localhost:8080/docs to open SwaggerUI. Press any key to exit."}else{"Server started at http://localhost:8080. Press any key to exit."})
+      _ <- Console.printLine("@if(addDocumentation){Go to http://localhost:8080/docs to open SwaggerUI.}else{Server started at http://localhost:8080.} Press ENTER key to exit.")
       _ <- Console.readLine
     } yield serverStart)
       .provideSomeLayer(EventLoopGroup.auto(0) ++ ServerChannelFactory.auto ++ Scope.default)

--- a/backend/src/test/scala/com/softwaremill/adopttapir/template/ProjectTemplateInTests.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/template/ProjectTemplateInTests.scala
@@ -10,22 +10,25 @@ class ProjectTemplateInTests(config: StarterConfig) extends ProjectTemplate(conf
     val groupId = starterDetails.groupId
 
     val metricsServerStub = FrameworkEndpointsSpecView.getMetricsServerStub(starterDetails)
+    val docsServerStub = FrameworkEndpointsSpecView.getDocsServerStub(starterDetails)
 
     val fileContent =
       if (starterDetails.serverEffect == ZIOEffect) {
         txt
           .FrameworkEndpointsSpecZIO(
             starterDetails,
-            toSortedList(metricsServerStub.imports),
-            metricsServerStub.body
+            toSortedList(metricsServerStub.imports ++ docsServerStub.imports),
+            metricsServerStub.body,
+            docsServerStub.body
           )
       } else {
         val unwrapper = EndpointsSpecView.Unwrapper.prepareUnwrapper(starterDetails.serverEffect)
         txt
           .FrameworkEndpointsSpec(
             starterDetails,
-            toSortedList(metricsServerStub.imports ++ unwrapper.imports),
+            toSortedList(metricsServerStub.imports ++ docsServerStub.imports ++ unwrapper.imports),
             metricsServerStub.body,
+            docsServerStub.body,
             unwrapper.body
           )
       }

--- a/backend/src/test/scala/com/softwaremill/adopttapir/template/scala/FrameworkEndpointsSpecView.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/template/scala/FrameworkEndpointsSpecView.scala
@@ -1,11 +1,47 @@
 package com.softwaremill.adopttapir.template.scala
 
-import com.softwaremill.adopttapir.starter.StarterDetails
+import com.softwaremill.adopttapir.starter.{ServerEffect, StarterDetails}
 import com.softwaremill.adopttapir.template.scala.EndpointsSpecView.Stub
 import com.softwaremill.adopttapir.template.scala.EndpointsView.Constants.metricsEndpoint
 
 object FrameworkEndpointsSpecView {
   def getMetricsServerStub(starterDetails: StarterDetails): Code = {
     if (starterDetails.addMetrics) Stub.prepareBackendStub(metricsEndpoint, starterDetails.serverEffect) else Code.empty
+  }
+
+  def getDocsServerStub(starterDetails: StarterDetails): Code = {
+    if (starterDetails.addDocumentation) prepareDocsStub(starterDetails.serverEffect) else Code.empty
+  }
+
+  private def prepareDocsStub(serverEffect: ServerEffect): Code = {
+    val stub = serverEffect match {
+      case ServerEffect.FutureEffect => "SttpBackendStub.asynchronousFuture"
+      case ServerEffect.IOEffect     => "SttpBackendStub(new CatsMonadError[IO]())"
+      case ServerEffect.ZIOEffect    => "SttpBackendStub(new RIOMonadError[Any])"
+    }
+
+    val body =
+      s"""val backendStub = TapirStubInterpreter($stub)
+         |  .whenServerEndpointsRunLogic(docEndpoints)
+         |  .backend()""".stripMargin
+
+    val imports = serverEffect match {
+      case ServerEffect.FutureEffect =>
+        Set(
+          Import("scala.concurrent.Future"),
+          Import("scala.concurrent.ExecutionContext.Implicits.global")
+        )
+      case ServerEffect.IOEffect =>
+        Set(
+          Import("cats.effect.IO"),
+          Import("sttp.tapir.integ.cats.CatsMonadError")
+        )
+      case ServerEffect.ZIOEffect =>
+        Set(
+          Import("sttp.tapir.ztapir.RIOMonadError")
+        )
+    }
+
+    Code(body, imports)
   }
 }

--- a/backend/src/test/twirl/FrameworkEndpointsSpec.scala.txt
+++ b/backend/src/test/twirl/FrameworkEndpointsSpec.scala.txt
@@ -2,6 +2,7 @@
 starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
 additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
 metricsStub: String,
+docsStub: String,
 unwrapper: String,
 )
 package @{starterDetails.groupId}
@@ -37,6 +38,22 @@ class FrameworkEndpointsSpec extends AnyFlatSpec with Matchers with EitherValues
           and include("# HELP tapir_request_active Active HTTP requests")
           and include("# TYPE tapir_request_active gauge"))
       )
+      .unwrap
+  }
+}
+@if(docsStub.nonEmpty){
+  it should "return docs document" in {
+    // given
+    @docsStub
+
+    // when
+    val response = basicRequest
+      .get(uri"http://localhost/docs/docs.yaml")
+      .send(backendStub)
+
+    // then
+    response
+      .map(_.body.value should include("paths:\n  /hello:"))
       .unwrap
   }
 }

--- a/backend/src/test/twirl/FrameworkEndpointsSpecZIO.scala.txt
+++ b/backend/src/test/twirl/FrameworkEndpointsSpecZIO.scala.txt
@@ -1,7 +1,8 @@
 @(
 starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
 additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
-metricsStub: String
+metricsStub: String,
+docsStub: String,
 )
 package @{starterDetails.groupId}
 
@@ -36,6 +37,21 @@ object FrameworkEndpointsSpec extends ZIOSpecDefault {
             && containsString("# HELP tapir_request_active Active HTTP requests")
             && containsString("# TYPE tapir_request_active gauge")
         )
+      )
+    }
+}@if(docsStub.nonEmpty){@if(metricsStub.nonEmpty){,}
+    test("return docs document") {
+      // given
+      @docsStub
+
+      // when
+      val response = basicRequest
+        .get(uri"http://localhost/docs/docs.yaml")
+        .send(backendStub)
+
+      // then
+      assertZIO(response.map(_.body))(
+        isRight(containsString("paths:\n  /hello:"))
       )
     }
 }


### PR DESCRIPTION
When `addDocumentation` is selected and `StarterServiceITTest` is called
generate `FrameworkEndpointsSpec.scala` that verifies if docs
endpoint is available and returns expected result.
Note that the spec in question is only compiled for tests and doesn't
polute the generated production code.

For development purposes one can examine the spec by calling:
```
  com.softwaremill.adopttapir.starter.FileOperation
```
end examining their output.