### PR TITLE
chore: add possibility to restrict/run in parallel IT tests

### DIFF
--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         scala: [ "Scala2", "Scala3" ]
-        json: [ "No", "Circe", "Jsoniter", "ZIOJson" ]
+        json: [ "No", "Circe", "Jsoniter,ZIOJson" ]
 
     steps:
       - name: Check-out repository
@@ -44,8 +44,8 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
       - name: Run unit tests
-        # run unit tests only against the ZIOJson & Scala2 configuration so that resources are spared
-        if: matrix.scala == 'Scala2' && matrix.json == 'ZIOJson'
+        # run unit tests only against the No & Scala3 configuration so that resources are spared
+        if: matrix.scala == 'Scala3' && matrix.json == 'No'
         id: run-unit-tests
         run: sbt test
 

--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        scala: [ "Scala2", "Scala3" ]
         json: [ "No", "Circe", "Jsoniter", "ZIOJson" ]
 
     steps:
@@ -43,13 +44,13 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
       - name: Run unit tests
-        # run unit tests only against the ZIOJson configuration so that resources are spared
-        if: matrix.json == 'ZIOJson'
+        # run unit tests only against the ZIOJson & Scala2 configuration so that resources are spared
+        if: matrix.scala == 'Scala2' && matrix.json == 'ZIOJson'
         id: run-unit-tests
         run: sbt test
 
-      - name: Run integration tests with ${{ matrix.json }} JSON support
-        run: JSON=${{ matrix.json }} sbt 'ItTest / test'
+      - name: Run integration tests for ${{ matrix.scala }} with ${{ matrix.json }} JSON support
+        run: SCALA=${{ matrix.scala }} JSON=${{ matrix.json }} sbt 'ItTest / test'
 
   deploy:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -16,6 +16,10 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        json: [ "No", "Circe", "Jsoniter", "ZIOJson" ]
 
     steps:
       - name: Check-out repository
@@ -38,9 +42,14 @@ jobs:
             ~/.coursier
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
-      - name: Run tests
-        id: run-tests
-        run: sbt ';test ;ItTest / test'
+      - name: Run unit tests
+        # run unit tests only against the ZIOJson configuration so that resources are spared
+        if: matrix.json == 'ZIOJson'
+        id: run-unit-tests
+        run: sbt test
+
+      - name: Run integration tests with ${{ matrix.json }} JSON support
+        run: JSON=${{ matrix.json }} sbt 'ItTest / test'
 
   deploy:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ that additional group needs to be called:
 sbt ';test ;ItTest / test'
 ```
 
-Note that `ItTest` can be restricted (or run in parallel) by JSON implementation e.g.
+Note that `ItTest` can be restricted (or run in parallel) by Scala or JSON implementations e.g.
 
 ```shell
-JSON="Circe,No" sbt 'ItTest / test'
+SCALA=Scala2 JSON="Circe,No" sbt 'ItTest / test'
 ```
 
-results in running integration tests only for configurations that JSON is either disabled (`No`) or using `Circe`
-implementation.
+results in running integration tests only for `Scala 2` configurations that JSON is either disabled (`No`) or using
+`Circe` implementation.
 
 ### Frontend: webapp
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ that additional group needs to be called:
 sbt ';test ;ItTest / test'
 ```
 
+Note that `ItTest` can be restricted (or run in parallel) by JSON implementation e.g.
+
+```shell
+JSON="Circe,No" sbt 'ItTest / test'
+```
+
+results in running integration tests only for configurations that JSON is either disabled (`No`) or using `Circe`
+implementation.
+
 ### Frontend: webapp
 
 In order to locally run and build frontend webapp you need to have the following tools:

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
@@ -65,6 +65,9 @@ sealed trait JsonImplementationRequest extends EnumEntry {
   def toModel: JsonImplementation
 }
 
+/** Changes in JSON implementation have to be reflected in .github/workflows/adopt-tapir-ci.yml file so that running jobs in parallel is
+  * still possible
+  */
 object JsonImplementationRequest extends Enum[JsonImplementationRequest] with CirceEnum[JsonImplementationRequest] {
   case object No extends JsonImplementationRequest {
     override def toModel: JsonImplementation = JsonImplementation.WithoutJson

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
@@ -92,6 +92,9 @@ sealed trait ScalaVersionRequest extends EnumEntry {
   def toModel: ScalaVersion
 }
 
+/** Changes in Scala versions have to be reflected in .github/workflows/adopt-tapir-ci.yml file so that running jobs in parallel is
+ * still possible
+ */
 object ScalaVersionRequest extends Enum[ScalaVersionRequest] with CirceEnum[ScalaVersionRequest] {
   case object Scala2 extends ScalaVersionRequest {
     override def toModel: ScalaVersion = ScalaVersion.Scala2

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -18,16 +18,24 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.util.Using
+import scala.util.{Properties, Using}
 import scala.util.matching.Regex
 
 object Setup {
+  lazy val jsonImplementations: List[JsonImplementationRequest] = {
+    Properties
+      .envOrElse("JSON", JsonImplementationRequest.values.mkString(","))
+      .split(",")
+      .map(JsonImplementationRequest.withName)
+      .toList
+  }
+
   val validConfigurations: Seq[StarterDetails] = for {
     effect <- EffectRequest.values
     server <- ServerImplementationRequest.values
     docs <- List(true, false)
     metrics <- List(true, false)
-    json <- JsonImplementationRequest.values
+    json <- jsonImplementations
     scalaVersion <- ScalaVersionRequest.values
     starterRequest = StarterRequest(
       "myproject",

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -30,13 +30,17 @@ object Setup {
       .toList
   }
 
+  lazy val scalaVersions: List[ScalaVersionRequest] = {
+    Properties.envOrElse("SCALA", ScalaVersionRequest.values.mkString(",")).split(",").map(ScalaVersionRequest.withName).toList
+  }
+
   val validConfigurations: Seq[StarterDetails] = for {
     effect <- EffectRequest.values
     server <- ServerImplementationRequest.values
     docs <- List(true, false)
     metrics <- List(true, false)
     json <- jsonImplementations
-    scalaVersion <- ScalaVersionRequest.values
+    scalaVersion <- scalaVersions
     starterRequest = StarterRequest(
       "myproject",
       "com.softwaremill",


### PR DESCRIPTION
At present running IT tests in CI takes ~28m. Add possibility to
scale configurations to multiple nodes over JSON implementation and
Scala version values.

By default nothing changes and all configurations are executed however
one can restrict them by providing comma separated values to JSON env
variable e.g:
```
  JSON="Circe,No" sbt 'ItTest / test'
```
results in running integration tests only for configurations that JSON
is either disabled (`No`) or using `Circe` implementation.
It is used in CI to spawn 4 jobs in parallel.

Additionally one can restrict it with Scala version e.g. combined with JSON

```
  JSON=No SCALA=Scala2 sbt 'ItTest / test'
```

results in integration tests for `Scala 2` with JSON disabled being integration
tested.

Closes #97.