### PR TITLE
fix: ignore IO exceptions during IT resources cleanup 

### DIFF
--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -146,7 +146,7 @@ case class ServiceUnderTest(details: StarterDetails) {
   }
 
   private def createTempDirectory(): Resource[IO, BFile] = {
-    Resource.make(IO.blocking(BFile.newTemporaryDirectory("sbtTesting")))(tempDir => IO.blocking(tempDir.delete()))
+    Resource.make(IO.blocking(BFile.newTemporaryDirectory("sbtTesting")))(tempDir => IO.blocking(tempDir.delete(true)))
   }
 
   private def unzipFile(zipFile: BFile, tempDir: BFile, logger: RunLogger): IO[Unit] = {


### PR DESCRIPTION
The `file.delete` for directory sometimes fails on recursive directories
removal. Set it to ignore IO exceptions as temp directory is going to be
removed anyway by system.

Part of #99.