### PR TITLE
chore: remove scala version from starter config

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterConfig.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterConfig.scala
@@ -2,7 +2,5 @@ package com.softwaremill.adopttapir.starter
 
 case class StarterConfig(
     deleteTempFolder: Boolean,
-    tempPrefix: String,
-    // TODO: In future it will be moved to the request.
-    scalaVersion: String
+    tempPrefix: String
 )

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectTemplate.scala
@@ -2,7 +2,7 @@ package com.softwaremill.adopttapir.template
 
 import better.files.Resource
 import com.softwaremill.adopttapir.starter.ServerEffect.ZIOEffect
-import com.softwaremill.adopttapir.starter.{ScalaVersion, StarterConfig, StarterDetails}
+import com.softwaremill.adopttapir.starter.{ScalaVersion, StarterDetails}
 import com.softwaremill.adopttapir.template.ProjectTemplate._
 import com.softwaremill.adopttapir.template.sbt.BuildSbtView
 import com.softwaremill.adopttapir.template.scala.{EndpointsSpecView, EndpointsView, Import, MainView}
@@ -18,7 +18,7 @@ case class GeneratedFile(
   *
   * As an example see @see [[EndpointsView]]
   */
-class ProjectTemplate(config: StarterConfig) {
+class ProjectTemplate {
 
   def getBuildSbt(starterDetails: StarterDetails): GeneratedFile = {
     val content = txt

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
@@ -8,7 +8,7 @@ import com.softwaremill.adopttapir.template.ProjectTemplate
 object FileOperation extends IOApp {
 
   private val cfg = Config.read.starter
-  val service = new StarterService(cfg.copy(deleteTempFolder = false), new ProjectTemplate(cfg))
+  val service = new StarterService(cfg.copy(deleteTempFolder = false), new ProjectTemplate)
 
   override def run(args: List[String]): IO[ExitCode] = {
     val details = StarterDetails(

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -249,8 +249,8 @@ case class Service(tempDir: better.files.File) {
 
 object ZipGenerator {
   val service: StarterService = {
-    val config = StarterConfig(deleteTempFolder = true, tempPrefix = "sbtService", scalaVersion = "2.13.8")
-    new StarterService(config, new ProjectTemplate(config))
+    val config = StarterConfig(deleteTempFolder = true, tempPrefix = "sbtService")
+    new StarterService(config, new ProjectTemplate)
   }
 }
 


### PR DESCRIPTION
Scala version is part of the request and as such is no longer needed to be
preconfigured. Remove it from the StarterConfig and remove StarterConfig
from ProjectTemplate parameters as it is no longer used there.