### PR TITLE
chore: upgrade GitHub CI base image to 22.04

### DIFF
--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Currently version `18.04` is used and it is being flagged in CI that
this version is deprecated with the following warning:

```
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```

Closes #117