### PR TITLE
chore: upgrade CI components

### DIFF
--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -25,17 +25,19 @@ jobs:
     steps:
       - name: Check-out repository
         id: repo-checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         id: jdk-setup
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
 
       - name: Cache SBT
         id: cache-sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt
@@ -66,17 +68,19 @@ jobs:
     steps:
       - name: Check-out repository
         id: repo-checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         id: jdk-setup
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
 
       - name: Cache SBT
         id: cache-sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -8,16 +8,19 @@ on:
 
 jobs:
   scala-steward:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        id: jdk-setup
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ def versionWithTimestamp(version: String): String = s"$version-${System.currentT
 
 lazy val dockerSettings = Seq(
   dockerExposedPorts := Seq(8080),
-  dockerBaseImage := "adoptopenjdk:11.0.5_10-jdk-hotspot",
+  dockerBaseImage := "eclipse-temurin:17.0.4_8-jdk-jammy",
   Docker / packageName := "adopttapir",
   dockerUsername := Some("softwaremill"),
   dockerUpdateLatest := true,


### PR DESCRIPTION
The following components were updated for both CI workflow and Scala
Steward (unless mentioned):
* ubuntu to 22.04 (Scala Steward)
* JDK to version 17 (the latest LTS)
* actions/checkout to v3
* actions/setup-java to v3
* actions/cache to v3
* note that docker base image was also upgraded to JDK 17
  ('eclipse-temurin:17.0.4_8-jdk-jammy' to be precise)