### PR TITLE
feat: add builder selection to adopt-tapir UI

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/metrics/Metrics.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/metrics/Metrics.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.adopttapir.metrics
 
 import com.softwaremill.adopttapir.starter.ScalaVersion._
-import com.softwaremill.adopttapir.starter.{JsonImplementation, ServerEffect, ServerImplementation, StarterDetails}
+import com.softwaremill.adopttapir.starter._
 import io.prometheus.client.{Counter, hotspot}
 
 object Metrics {
@@ -21,7 +21,17 @@ object Metrics {
 
   private val starterDetailsLabels: Array[String] = {
     val fakeInstance: StarterDetails =
-      StarterDetails("", "", ServerEffect.IOEffect, ServerImplementation.Akka, true, false, JsonImplementation.WithoutJson, Scala2)
+      StarterDetails(
+        "",
+        "",
+        ServerEffect.IOEffect,
+        ServerImplementation.Akka,
+        true,
+        false,
+        JsonImplementation.WithoutJson,
+        Scala2,
+        Builder.Sbt
+      )
 
     val names = fakeInstance.productElementNames.toArray.filterNot(excludedStarterDetailsFields.contains)
     require(

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterModel.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterModel.scala
@@ -14,7 +14,7 @@ case class StarterDetails(
     addMetrics: Boolean,
     jsonImplementation: JsonImplementation,
     scalaVersion: ScalaVersion,
-    builder: Builder = Builder.Sbt // TODO: remove default once UI is finished
+    builder: Builder
 )
 
 sealed trait ServerImplementation

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
@@ -12,7 +12,7 @@ case class StarterRequest(
     addMetrics: Boolean,
     json: JsonImplementationRequest,
     scalaVersion: ScalaVersionRequest,
-    builder: BuilderRequest = BuilderRequest.Sbt // TODO: remove default once UI is finished
+    builder: BuilderRequest
 )
 
 object StarterRequest {}
@@ -93,9 +93,9 @@ sealed trait ScalaVersionRequest extends EnumEntry {
   def toModel: ScalaVersion
 }
 
-/** Changes in Scala versions have to be reflected in .github/workflows/adopt-tapir-ci.yml file so that running jobs in parallel is
- * still possible
- */
+/** Changes in Scala versions have to be reflected in .github/workflows/adopt-tapir-ci.yml file so that running jobs in parallel is still
+  * possible
+  */
 object ScalaVersionRequest extends Enum[ScalaVersionRequest] with CirceEnum[ScalaVersionRequest] {
   case object Scala2 extends ScalaVersionRequest {
     override def toModel: ScalaVersion = ScalaVersion.Scala2

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
@@ -19,7 +19,8 @@ object FileOperation extends IOApp {
       true,
       false,
       JsonImplementation.Circe,
-      ScalaVersion.Scala2
+      ScalaVersion.Scala2,
+      Builder.ScalaCli
     )
 
     for {

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/FormValidatorTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/FormValidatorTest.scala
@@ -7,7 +7,7 @@ import com.softwaremill.adopttapir.starter.api.JsonImplementationRequest.No
 import com.softwaremill.adopttapir.starter.api.ScalaVersionRequest.Scala3
 import com.softwaremill.adopttapir.starter.api.ServerImplementationRequest.{Akka, Http4s, Netty, ZIOHttp}
 import com.softwaremill.adopttapir.starter.api.StarterRequestGenerators.randomStarterRequest
-import com.softwaremill.adopttapir.starter.{ServerEffect, ServerImplementation, StarterDetails}
+import com.softwaremill.adopttapir.starter.{Builder, ServerEffect, ServerImplementation, StarterDetails}
 import com.softwaremill.adopttapir.test.BaseTest
 
 class FormValidatorTest extends BaseTest {
@@ -87,7 +87,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       false,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request1).value shouldBe StarterDetails(
       request1.projectName,
@@ -97,7 +98,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       false,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request2).value shouldBe StarterDetails(
       request2.projectName,
@@ -107,7 +109,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       false,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request3).value shouldBe StarterDetails(
       request3.projectName,
@@ -117,7 +120,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       false,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request4).value shouldBe StarterDetails(
       request4.projectName,
@@ -127,7 +131,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       false,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request5).value shouldBe StarterDetails(
       request5.projectName,
@@ -137,7 +142,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       false,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
   }
 
@@ -155,7 +161,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       true,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request1).value shouldBe StarterDetails(
       request1.projectName,
@@ -165,7 +172,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       true,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request2).value shouldBe StarterDetails(
       request2.projectName,
@@ -175,7 +183,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       true,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
     FormValidator.validate(request3).value shouldBe StarterDetails(
       request3.projectName,
@@ -185,7 +194,8 @@ class FormValidatorTest extends BaseTest {
       addDocumentation = true,
       true,
       WithoutJson,
-      Scala2
+      Scala2,
+      Builder.Sbt
     )
   }
 
@@ -198,5 +208,15 @@ class FormValidatorTest extends BaseTest {
   }
 
   private def defaultRequest(): StarterRequest =
-    StarterRequest("project", "com.softwaremill", FutureEffect, Akka, addDocumentation = true, false, No, ScalaVersionRequest.Scala2)
+    StarterRequest(
+      "project",
+      "com.softwaremill",
+      FutureEffect,
+      Akka,
+      addDocumentation = true,
+      false,
+      No,
+      ScalaVersionRequest.Scala2,
+      BuilderRequest.Sbt
+    )
 }

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
@@ -151,7 +151,8 @@ object StarterApiTest {
     addDocumentation = true,
     addMetrics = false,
     json = Jsoniter,
-    scalaVersion = Scala2
+    scalaVersion = Scala2,
+    builder = BuilderRequest.Sbt
   )
 
   val validScalaCliRequest: StarterRequest = validSbtRequest.copy(builder = BuilderRequest.ScalaCli)

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterRequestGenerators.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterRequestGenerators.scala
@@ -21,6 +21,7 @@ object StarterRequestGenerators {
       metricsAdded <- Gen.oneOf(true, false)
       json <- Gen.oneOf(JsonImplementationRequest.values)
       scalaVersion <- Gen.oneOf(ScalaVersionRequest.values)
+      builder <- Gen.oneOf(BuilderRequest.values)
     } yield StarterRequest(
       projectName,
       groupId,
@@ -29,7 +30,8 @@ object StarterRequestGenerators {
       documentationAdded,
       metricsAdded,
       json,
-      scalaVersion
+      scalaVersion,
+      builder
     )
   }
 }

--- a/ui/src/api/starter.ts
+++ b/ui/src/api/starter.ts
@@ -23,6 +23,11 @@ export enum ScalaVersion {
   Scala3 = 'Scala3',
 }
 
+export enum Builder {
+  Sbt = 'Sbt',
+  ScalaCli = 'ScalaCli',
+}
+
 export type StarterRequest = {
   projectName: string;
   groupId: string;
@@ -32,4 +37,5 @@ export type StarterRequest = {
   addMetrics: boolean;
   json: JSONImplementation;
   scalaVersion: ScalaVersion;
+  builder: Builder;
 };

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -4,7 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { DevTool } from '@hookform/devtools';
 import { saveAs } from 'file-saver';
-import { JSONImplementation, ScalaVersion, StarterRequest } from 'api/starter';
+import { Builder, JSONImplementation, ScalaVersion, StarterRequest } from 'api/starter';
 import { useApiCall } from 'hooks/useApiCall';
 import { isDevelopment } from 'consts/env';
 import { FormTextField } from '../FormTextField';
@@ -12,6 +12,7 @@ import { FormSelect } from '../FormSelect';
 import { FormRadioGroup } from '../FormRadioGroup';
 import { useStyles } from './ConfigurationForm.styles';
 import {
+  BUILDER_OPTIONS,
   EFFECT_TYPE_OPTIONS,
   ENDPOINTS_OPTIONS,
   SCALA_VERSION_OPTIONS,
@@ -40,6 +41,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
       addMetrics: false,
       json: JSONImplementation.No,
       scalaVersion: ScalaVersion.Scala3,
+      builder: Builder.Sbt,
     },
   });
 
@@ -162,6 +164,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
             disabled={!isEffectImplementationSelectable}
             options={isEffectImplementationSelectable ? getEffectImplementationOptions(effectType, scalaVersion) : []}
           />
+          <FormRadioGroup className={classes.formThirdRow} name="builder" label="Builder" options={BUILDER_OPTIONS} />
 
           <FormRadioGroup
             className={classes.formFourthRow}

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
@@ -1,5 +1,12 @@
 import * as yup from 'yup';
-import { EffectImplementation, EffectType, JSONImplementation, ScalaVersion, StarterRequest } from 'api/starter';
+import {
+  Builder,
+  EffectImplementation,
+  EffectType,
+  JSONImplementation,
+  ScalaVersion,
+  StarterRequest,
+} from 'api/starter';
 import type { FormSelectOption } from '../FormSelect';
 import type { FormRadioOption } from '../FormRadioGroup';
 import {
@@ -83,6 +90,17 @@ export const JSON_OUTPUT_OPTIONS: FormRadioOption<JSONImplementation>[] = [
   },
 ];
 
+export const BUILDER_OPTIONS: FormRadioOption<Builder>[] = [
+  {
+    label: 'sbt',
+    value: Builder.Sbt,
+  },
+  {
+    label: 'Scala CLI',
+    value: Builder.ScalaCli,
+  },
+];
+
 const labelGetter = (
   option: FormSelectOption | FormRadioOption
 ): FormSelectOption['label'] | FormRadioOption['label'] => option.label;
@@ -155,5 +173,12 @@ export const starterValidationSchema = yup
       })
       .required(REQUIRED_FIELD_MESSAGE),
     addMetrics: yup.boolean().required(REQUIRED_FIELD_MESSAGE),
+    builder: yup
+      .mixed()
+      .oneOf(
+        BUILDER_OPTIONS.map(valueGetter),
+        `Builder must be one of the following values: ${BUILDER_OPTIONS.map(labelGetter).join(', ')}`
+      )
+      .required(REQUIRED_FIELD_MESSAGE),
   })
   .required();

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.styles.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.styles.ts
@@ -29,6 +29,8 @@ export const useStyles = makeStyles<{ isEmbedded: boolean }>()((theme, { isEmbed
       },
     },
     formThirdRow: {
+      alignSelf: 'center',
+
       [theme.breakpoints.up(breakpoint)]: {
         gridRowStart: 3,
       },

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.component.test.tsx
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.component.test.tsx
@@ -27,6 +27,8 @@ describe('ConfigurationForm component', () => {
     await user.click(screen.getByRole('button', { name: /Server implementation/i }));
     await user.click(screen.getByText('Akka HTTP'));
 
+    await user.click(within(screen.getByRole('radiogroup', { name: /Builder/i })).getByText('Scala CLI'));
+
     await user.click(
       within(
         screen.getByRole('radiogroup', {
@@ -52,6 +54,7 @@ describe('ConfigurationForm component', () => {
       },
       // NOTE: below order matters as we are comparing strings
       body: JSON.stringify({
+        builder: 'ScalaCli',
         addMetrics: true,
         effect: 'FutureEffect',
         json: 'Circe',
@@ -119,6 +122,8 @@ describe('ConfigurationForm component', () => {
     await user.click(screen.getByRole('button', { name: /Server implementation/i }));
     await user.click(screen.getByText('Akka HTTP'));
 
+    await user.click(within(screen.getByRole('radiogroup', { name: /Builder/i })).getByText('Scala CLI'));
+
     await user.click(
       within(
         screen.getByRole('radiogroup', {
@@ -138,6 +143,7 @@ describe('ConfigurationForm component', () => {
       effect: '',
       scalaVersion: 'Scala3',
       implementation: '',
+      builder: 'Sbt',
       addDocumentation: 'false',
       json: 'No',
       addMetrics: 'false',

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.consts.test.ts
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.consts.test.ts
@@ -1,5 +1,12 @@
 import * as yup from 'yup';
-import { EffectType, EffectImplementation, ScalaVersion, JSONImplementation, StarterRequest } from 'api/starter';
+import {
+  Builder,
+  EffectImplementation,
+  EffectType,
+  JSONImplementation,
+  ScalaVersion,
+  StarterRequest,
+} from 'api/starter';
 import { starterValidationSchema } from '../ConfigurationForm.consts';
 
 const TEST_FORM_VALUES: StarterRequest = {
@@ -11,6 +18,7 @@ const TEST_FORM_VALUES: StarterRequest = {
   addDocumentation: false,
   json: JSONImplementation.No,
   addMetrics: false,
+  builder: Builder.Sbt,
 };
 
 describe('configuration consts', () => {
@@ -240,6 +248,21 @@ describe('configuration consts', () => {
           expect(addMetricsSchema.isValidSync(addMetrics)).toBe(expected);
         }
       );
+    });
+
+    describe('builder field', () => {
+      const builderSchema = yup.reach(starterValidationSchema, 'builder');
+      const cases: { builder: Builder | undefined; expected: boolean }[] = [
+        { builder: Builder.Sbt, expected: true },
+        { builder: Builder.ScalaCli, expected: true },
+        { builder: 'notScalaVersion' as Builder, expected: false },
+        { builder: '' as Builder, expected: false },
+        { builder: undefined, expected: false },
+      ];
+
+      test.each(cases)('should return $expected based on builder [$builder] validity', ({ builder, expected }) => {
+        expect(builderSchema.isValidSync(builder)).toBe(expected);
+      });
     });
   });
 });


### PR DESCRIPTION
New radio button group was added to the UI ('Builder') that contains the
following values (according to their web page names):
* sbt (default)
* Scala CLI

Here is the upgraded `adopt-tapir` configuration form with the default values:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/3641082/184352357-1c3247a0-3e0d-4e05-9c0d-26898b3ea581.png">


Notes:
* UI tests were extended to validate new configuration values
* default builder value (Sbt) was removed from StarterRequest and
  StarterDetails as it is supported in UI now
* new fronted was successfully, manually tested against
  https://adopt-tapir.softwaremill.com/ as backend is already deployed

Closes #45