### PR TITLE
Creating list of endpoints once

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
@@ -51,28 +51,30 @@ abstract class ProjectTemplate {
     val groupId = starterDetails.legalizedGroupId
 
     val helloServerEndpoint = EndpointsView.getHelloServerEndpoint(starterDetails)
-    val docEndpoints = EndpointsView.getDocEndpoints(starterDetails)
-    val metricsEndpoint = EndpointsView.getMetricsEndpoint(starterDetails)
     val jsonEndpoint = EndpointsView.getJsonOutModel(starterDetails)
     val library = EndpointsView.getJsonLibrary(starterDetails)
+    val apiEndpoints = EndpointsView.getApiEndpoints(starterDetails)
+    val docEndpoints = EndpointsView.getDocEndpoints(starterDetails)
+    val metricsEndpoint = EndpointsView.getMetricsEndpoint(starterDetails)
     val allEndpoints = EndpointsView.getAllEndpoints(starterDetails)
 
     GeneratedFile(
       pathUnderPackage("src/main/scala", groupId, "Endpoints.scala"),
       txt
         .Endpoints(
-          starterDetails,
-          toSortedList(
+          starterDetails = starterDetails,
+          additionalImports = toSortedList(
             helloServerEndpoint.imports ++ metricsEndpoint.imports ++ docEndpoints.imports
               ++ jsonEndpoint.imports ++ library.imports ++ allEndpoints.imports
           ),
-          helloServerEndpoint.body,
-          metricsEndpoint.body,
-          docEndpoints.body,
+          helloEndpointServer = helloServerEndpoint.body,
           jsonEndpoint = jsonEndpoint.body,
-          library.body,
-          allEndpoints.body,
-          starterDetails.scalaVersion
+          library = library.body,
+          apiEndpoints = apiEndpoints.body,
+          docEndpoints = docEndpoints.body,
+          metricsEndpoint = metricsEndpoint.body,
+          allEndpoints = allEndpoints.body,
+          scalaVersion = starterDetails.scalaVersion
         )
         .toString()
     )

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
@@ -135,8 +135,8 @@ object EndpointsView {
     private def prepareBookListingServerLogic(starterDetails: StarterDetails): Code = {
       val (serverKind, pureEffectFn) = starterDetails.serverEffect match {
         case ServerEffect.FutureEffect => ("ServerEndpoint[Any, Future]", "Future.successful")
-        case ServerEffect.IOEffect => ("ServerEndpoint[Any, IO]", "IO.pure")
-        case ServerEffect.ZIOEffect => ("ZServerEndpoint[Any, Any]", "ZIO.succeed")
+        case ServerEffect.IOEffect     => ("ServerEndpoint[Any, IO]", "IO.pure")
+        case ServerEffect.ZIOEffect    => ("ZServerEndpoint[Any, Any]", "ZIO.succeed")
       }
 
       // Imports silently taken from helloServerEndpoint

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
@@ -152,18 +152,14 @@ object EndpointsView {
   def getApiEndpoints(starterDetails: StarterDetails): Code = {
     val serverKind = starterDetails.serverEffect match {
       case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
-      case ServerEffect.IOEffect => "List[ServerEndpoint[Any, IO]]"
-      case ServerEffect.ZIOEffect => "List[ZServerEndpoint[Any, Any]]"
+      case ServerEffect.IOEffect     => "List[ServerEndpoint[Any, IO]]"
+      case ServerEffect.ZIOEffect    => "List[ZServerEndpoint[Any, Any]]"
     }
 
     val jsonEndpoint = if (starterDetails.jsonImplementation == JsonImplementation.WithoutJson) Nil else List(booksListingServerEndpoint)
     val endpoints = List(helloServerEndpoint) ++ jsonEndpoint
     Code(
-      s"val ${apiEndpoints}: ${serverKind} = List(${
-        endpoints.mkString(
-          ","
-        )
-      })"
+      s"val ${apiEndpoints}: ${serverKind} = List(${endpoints.mkString(",")})"
     ).prependBody(INDENT)
   }
 
@@ -218,15 +214,15 @@ object EndpointsView {
   private def serverEffectToEffectAndEndpoint(serverEffect: ServerEffect): (String, String) = {
     serverEffect match {
       case ServerEffect.FutureEffect => ("Future", "ServerEndpoint[Any, Future]")
-      case ServerEffect.IOEffect => ("IO", "ServerEndpoint[Any, IO]")
-      case ServerEffect.ZIOEffect => ("Task", "ZServerEndpoint[Any, Any]")
+      case ServerEffect.IOEffect     => ("IO", "ServerEndpoint[Any, IO]")
+      case ServerEffect.ZIOEffect    => ("Task", "ZServerEndpoint[Any, Any]")
     }
   }
 
   private def serverEffectImports(serverEffect: ServerEffect): Set[Import] = {
     serverEffect match {
       case ServerEffect.ZIOEffect => Set(Import("zio.Task"))
-      case _ => Set.empty[Import]
+      case _                      => Set.empty[Import]
     }
   }
 

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
@@ -16,57 +16,6 @@ object EndpointsView {
     helloServerCode.prependBody(INDENT)
   }
 
-  def getMetricsEndpoint(starterDetails: StarterDetails): Code =
-    if (starterDetails.addMetrics) {
-      MetricsEndpoint.prepareMetricsEndpoint(starterDetails.serverEffect)
-    } else {
-      Code.empty
-    }
-
-  def getDocEndpoints(starterDetails: StarterDetails): Code = {
-    if (starterDetails.addDocumentation) {
-      DocumentationEndpoint.prepareDocEndpoints(
-        starterDetails.projectName,
-        starterDetails.serverEffect,
-        starterDetails.addMetrics,
-        starterDetails.jsonImplementation
-      )
-    } else
-      Code.empty
-  }
-
-  def getJsonOutModel(starterDetails: StarterDetails): Code = {
-    JsonModelObject.prepareJsonEndpoint(starterDetails)
-  }
-
-  def getJsonLibrary(starterDetails: StarterDetails): Code = {
-    if (starterDetails.jsonImplementation == JsonImplementation.WithoutJson) Code.empty
-    else JsonModelObject.prepareLibraryModel(starterDetails.scalaVersion)
-  }
-
-  def getAllEndpoints(starterDetails: StarterDetails): Code = {
-    val serverKind = starterDetails.serverEffect match {
-      case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
-      case ServerEffect.IOEffect     => "List[ServerEndpoint[Any, IO]]"
-      case ServerEffect.ZIOEffect    => "List[ZServerEndpoint[Any, Any]]"
-    }
-
-    val hasBooksListingEndpoint = starterDetails.jsonImplementation match {
-      case JsonImplementation.WithoutJson => false
-      case _                              => true
-    }
-
-    def bodyTemplate(serverKind: String, hasJson: Boolean, addMetrics: Boolean, hasDocumentation: Boolean): String = {
-      s"val ${Constants.all}: $serverKind = List($helloServerEndpoint" +
-        s"${if (hasJson) s", $booksListingServerEndpoint" else ""}" +
-        s"${if (addMetrics) s", $metricsEndpoint" else ""}" +
-        ")" +
-        s"${if (hasDocumentation) s" ++ $docEndpoints" else ""}"
-    }
-
-    Code(bodyTemplate(serverKind, hasBooksListingEndpoint, starterDetails.addMetrics, starterDetails.addDocumentation)).prependBody(INDENT)
-  }
-
   private object HelloServerEndpoint {
     def bodyTemplate(serverKind: String, pureEffectFn: String): String =
       s"""${INDENT}val $helloServerEndpoint: $serverKind = $helloEndpoint.serverLogicSuccess(user =>
@@ -96,6 +45,10 @@ object EndpointsView {
         Import("sttp.tapir.ztapir.ZServerEndpoint")
       )
     )
+  }
+
+  def getJsonOutModel(starterDetails: StarterDetails): Code = {
+    JsonModelObject.prepareJsonEndpoint(starterDetails)
   }
 
   private object JsonModelObject {
@@ -182,15 +135,74 @@ object EndpointsView {
     private def prepareBookListingServerLogic(starterDetails: StarterDetails): Code = {
       val (serverKind, pureEffectFn) = starterDetails.serverEffect match {
         case ServerEffect.FutureEffect => ("ServerEndpoint[Any, Future]", "Future.successful")
-        case ServerEffect.IOEffect     => ("ServerEndpoint[Any, IO]", "IO.pure")
-        case ServerEffect.ZIOEffect    => ("ZServerEndpoint[Any, Any]", "ZIO.succeed")
+        case ServerEffect.IOEffect => ("ServerEndpoint[Any, IO]", "IO.pure")
+        case ServerEffect.ZIOEffect => ("ZServerEndpoint[Any, Any]", "ZIO.succeed")
       }
 
       // Imports silently taken from helloServerEndpoint
       Code(s"val $booksListingServerEndpoint: $serverKind = $bookListing.serverLogicSuccess(_ => $pureEffectFn(Library.books))")
     }
-
   }
+
+  def getJsonLibrary(starterDetails: StarterDetails): Code = {
+    if (starterDetails.jsonImplementation == JsonImplementation.WithoutJson) Code.empty
+    else JsonModelObject.prepareLibraryModel(starterDetails.scalaVersion)
+  }
+
+  def getApiEndpoints(starterDetails: StarterDetails): Code = {
+    val serverKind = starterDetails.serverEffect match {
+      case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
+      case ServerEffect.IOEffect => "List[ServerEndpoint[Any, IO]]"
+      case ServerEffect.ZIOEffect => "List[ZServerEndpoint[Any, Any]]"
+    }
+
+    val jsonEndpoint = if (starterDetails.jsonImplementation == JsonImplementation.WithoutJson) Nil else List(booksListingServerEndpoint)
+    val endpoints = List(helloServerEndpoint) ++ jsonEndpoint
+    Code(
+      s"val ${apiEndpoints}: ${serverKind} = List(${
+        endpoints.mkString(
+          ","
+        )
+      })"
+    ).prependBody(INDENT)
+  }
+
+  def getDocEndpoints(starterDetails: StarterDetails): Code = {
+    if (starterDetails.addDocumentation) {
+      DocumentationEndpoint.prepareDocEndpoints(
+        starterDetails.projectName,
+        starterDetails.serverEffect
+      )
+    } else
+      Code.empty
+  }
+
+  private object DocumentationEndpoint {
+
+    def prepareDocEndpoints(
+                             projectName: String,
+                             serverEffect: ServerEffect,
+                           ): Code = {
+      Code(prepareCode(projectName, serverEffect), prepareImports(serverEffect)).prependBody(INDENT)
+    }
+
+    private def prepareCode(projectName: String, serverEffect: ServerEffect): String = {
+      val (effect, endpoint) = serverEffectToEffectAndEndpoint(serverEffect)
+      s"""val $docEndpoints: List[$endpoint] = SwaggerInterpreter()
+          .fromServerEndpoints[$effect](${apiEndpoints}, "$projectName", "1.0.0")""".stripMargin
+    }
+
+    def prepareImports(serverEffect: ServerEffect): Set[Import] = {
+      serverEffectImports(serverEffect) + Import("sttp.tapir.swagger.bundle.SwaggerInterpreter")
+    }
+  }
+
+  def getMetricsEndpoint(starterDetails: StarterDetails): Code =
+    if (starterDetails.addMetrics) {
+      MetricsEndpoint.prepareMetricsEndpoint(starterDetails.serverEffect)
+    } else {
+      Code.empty
+    }
 
   private object MetricsEndpoint {
     def prepareMetricsEndpoint(serverEffect: ServerEffect): Code = {
@@ -203,47 +215,36 @@ object EndpointsView {
     }
   }
 
-  private object DocumentationEndpoint {
-
-    def prepareDocEndpoints(
-        projectName: String,
-        serverEffect: ServerEffect,
-        addMetrics: Boolean,
-        jsonImplementation: JsonImplementation
-    ): Code = {
-
-      val metricsEndpoint = if (addMetrics) List(docMetricsEndpoint) else Nil
-      val jsonEndpoint = if (jsonImplementation == JsonImplementation.WithoutJson) Nil else List(bookListing)
-      val endpoints: List[String] = List(helloEndpoint) ++ metricsEndpoint ++ jsonEndpoint
-
-      Code(prepareCode(projectName, serverEffect, endpoints), prepareImports(serverEffect)).prependBody(INDENT)
-    }
-
-    private def prepareCode(projectName: String, serverEffect: ServerEffect, endpoints: List[String]): String = {
-      val (effect, endpoint) = serverEffectToEffectAndEndpoint(serverEffect)
-      s"""val $docEndpoints: List[$endpoint] = SwaggerInterpreter().fromEndpoints[$effect](List(${endpoints.mkString(
-          ","
-        )}), "$projectName", "1.0.0")""".stripMargin
-    }
-
-    def prepareImports(serverEffect: ServerEffect): Set[Import] = {
-      serverEffectImports(serverEffect) + Import("sttp.tapir.swagger.bundle.SwaggerInterpreter")
-    }
-  }
-
   private def serverEffectToEffectAndEndpoint(serverEffect: ServerEffect): (String, String) = {
     serverEffect match {
       case ServerEffect.FutureEffect => ("Future", "ServerEndpoint[Any, Future]")
-      case ServerEffect.IOEffect     => ("IO", "ServerEndpoint[Any, IO]")
-      case ServerEffect.ZIOEffect    => ("Task", "ZServerEndpoint[Any, Any]")
+      case ServerEffect.IOEffect => ("IO", "ServerEndpoint[Any, IO]")
+      case ServerEffect.ZIOEffect => ("Task", "ZServerEndpoint[Any, Any]")
     }
   }
 
   private def serverEffectImports(serverEffect: ServerEffect): Set[Import] = {
     serverEffect match {
       case ServerEffect.ZIOEffect => Set(Import("zio.Task"))
-      case _                      => Set.empty[Import]
+      case _ => Set.empty[Import]
     }
+  }
+
+  def getAllEndpoints(starterDetails: StarterDetails): Code = {
+    val serverKind = starterDetails.serverEffect match {
+      case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
+      case ServerEffect.IOEffect     => "List[ServerEndpoint[Any, IO]]"
+      case ServerEffect.ZIOEffect    => "List[ZServerEndpoint[Any, Any]]"
+    }
+
+    def bodyTemplate(serverKind: String, addMetrics: Boolean, hasDocumentation: Boolean): String = {
+      s"val ${Constants.all}: $serverKind = $apiEndpoints" +
+        s"${if (hasDocumentation) s" ++ $docEndpoints" else ""}" +
+        s"${if (addMetrics) s" ++ List($metricsEndpoint)" else ""}"
+
+    }
+
+    Code(bodyTemplate(serverKind, starterDetails.addMetrics, starterDetails.addDocumentation)).prependBody(INDENT)
   }
 
   object Constants {
@@ -253,9 +254,9 @@ object EndpointsView {
     val helloServerEndpoint = "helloServerEndpoint"
     val bookListing = "booksListing"
     val booksListingServerEndpoint = "booksListingServerEndpoint"
-    val metricsEndpoint = "metricsEndpoint"
-    val docMetricsEndpoint = "metricsEndpoint.endpoint"
+    val apiEndpoints = "apiEndpoints"
     val docEndpoints = "docEndpoints"
+    val metricsEndpoint = "metricsEndpoint"
     val all = "all"
   }
 }

--- a/backend/src/main/twirl/Endpoints.scala.txt
+++ b/backend/src/main/twirl/Endpoints.scala.txt
@@ -2,10 +2,11 @@
 starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
 additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
 helloEndpointServer: String,
-metricsEndpoint: String,
-docEndpoints: String,
 jsonEndpoint: String,
 library: String,
+apiEndpoints: String,
+docEndpoints: String,
+metricsEndpoint: String,
 allEndpoints: String,
 scalaVersion: com.softwaremill.adopttapir.starter.ScalaVersion,
 leftBracket: Char = '{',
@@ -27,9 +28,11 @@ object Endpoints@if(scalaVersion == com.softwaremill.adopttapir.starter.ScalaVer
 
 @jsonEndpoint
 
-@metricsEndpoint
+@apiEndpoints
 
 @docEndpoints
+
+@metricsEndpoint
 
 @allEndpoints
 @if(scalaVersion == com.softwaremill.adopttapir.starter.ScalaVersion.Scala2){@rightBracket}


### PR DESCRIPTION
* In generated project list of API endpoints is created once
* Updated endpoints order in case classes and template
* In `EndpointsView.scala` updated code order, so that it corresponds to the aforementioned changes