### PR TITLE
feat: introduce CommonSnackbar

### DIFF
--- a/ui/src/components/ApiCallAddons/ApiCallAddons.component.tsx
+++ b/ui/src/components/ApiCallAddons/ApiCallAddons.component.tsx
@@ -1,4 +1,5 @@
-import { Alert, Backdrop, CircularProgress, Snackbar } from '@mui/material';
+import { Backdrop, CircularProgress } from '@mui/material';
+import { CommonSnackbar } from '../CommonSnackbar';
 
 type Props = {
   isLoading: boolean;
@@ -12,16 +13,7 @@ export function ApiCallAddons({ isLoading, clearError, errorMessage }: Props) {
       <Backdrop open={isLoading}>
         <CircularProgress />
       </Backdrop>
-      <Snackbar
-        open={Boolean(errorMessage)}
-        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-        autoHideDuration={5000}
-        onClose={clearError}
-      >
-        <Alert severity="error" variant="outlined">
-          {errorMessage}
-        </Alert>
-      </Snackbar>
+      <CommonSnackbar onClose={clearError} open={Boolean(errorMessage)} />
     </>
   );
 }

--- a/ui/src/components/CommonSnackbar/CommonSnackbar.component.tsx
+++ b/ui/src/components/CommonSnackbar/CommonSnackbar.component.tsx
@@ -1,0 +1,26 @@
+import { Alert, AlertColor, Snackbar } from '@mui/material';
+
+type Props = {
+  onClose: () => void;
+  open: boolean;
+  duration?: number;
+  message?: String;
+  severity?: AlertColor;
+};
+
+export function CommonSnackbar({ onClose, open, severity, message, duration }: Props) {
+  return (
+    <>
+      <Snackbar
+        open={open}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        autoHideDuration={duration || 5000}
+        onClose={onClose}
+      >
+        <Alert onClose={onClose} severity={severity || 'error'} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/ui/src/components/CommonSnackbar/index.ts
+++ b/ui/src/components/CommonSnackbar/index.ts
@@ -1,0 +1,1 @@
+export * from './CommonSnackbar.component';

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -1,5 +1,5 @@
 import { SyntheticEvent, useContext, useEffect, useState } from 'react';
-import { Alert, AlertColor, Box, Button, IconButton, Snackbar, Stack, Tooltip, Typography } from '@mui/material';
+import { AlertColor, Box, Button, IconButton, Stack, Tooltip, Typography } from '@mui/material';
 import ShareTwoToneIcon from '@mui/icons-material/ShareTwoTone';
 import { FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -28,6 +28,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { ApiCallAddons } from '../ApiCallAddons';
 import { ConfigurationDataContext, resetFormData, setFormData } from '../../contexts';
 import { parse, stringifyUrl } from 'query-string';
+import { CommonSnackbar } from '../CommonSnackbar';
 
 interface ConfigurationFormProps {
   isEmbedded?: boolean;
@@ -208,16 +209,13 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
         </Stack>
       )}
 
-      <Snackbar
-        open={snackbar.open}
-        autoHideDuration={2500}
+      <CommonSnackbar
+        duration={2500}
+        message={snackbar.message}
         onClose={handleSnackClose}
-        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      >
-        <Alert onClose={handleSnackClose} severity={snackbar.severity} sx={{ width: '100%' }}>
-          {snackbar.message}
-        </Alert>
-      </Snackbar>
+        open={snackbar.open}
+        severity={snackbar.severity}
+      />
 
       <FormProvider {...form}>
         <form


### PR DESCRIPTION
There are two places where snackbar is used therefore it makes sense to introduce CommonSnackbar so that their look & feel is aligned. Considering these two usage the CommonSnackbar has properties according to this interface:

```
type Props = {
  onClose: () => void;
  open: boolean;
  duration?: number;
  message?: String;
  severity?: AlertColor;
};
```

Note that `ApiCallAddons` implementation contained `outlined` property additionally but it was gave up due to being less readable on smaller screens (overlapped with background).

Result of #75