### PR TITLE
feat: preview files ux improvements

### DIFF
--- a/ui/src/api/starter.ts
+++ b/ui/src/api/starter.ts
@@ -68,8 +68,6 @@ export async function doRequestStarter(formData: StarterRequest) {
   saveAs(blob, filename ?? 'starter.zip');
 }
 
-// TODO use dedicated endpoint.
-// Current request only simulates call to api. It will be replaced when endpoint is ready.
 export async function doRequestPreview(formData: StarterRequest, consumer: (resp: FileTree) => void) {
   const serverAddress = !process.env.REACT_APP_SERVER_ADDRESS
     ? 'https://adopt-tapir.softwaremill.com'

--- a/ui/src/components/FileTreeView/FileTreeView.component.tsx
+++ b/ui/src/components/FileTreeView/FileTreeView.component.tsx
@@ -1,6 +1,6 @@
 import { DirNode, FileNode, FileTree, TreeState } from './FileTreeView.types';
 import { useStyles } from './FileTreeView.styles';
-import { Folder, InsertDriveFileOutlined } from '@mui/icons-material';
+import { FolderOpenTwoTone, FolderTwoTone, InsertDriveFileOutlined } from '@mui/icons-material';
 import { NodeAbsoluteLocation } from './FileTreeView.utils';
 import { useEffect, useState } from 'react';
 
@@ -91,7 +91,7 @@ function DirNodeView({ node: { name, content }, location, state }: NodeProps<Dir
             state.toggleDir(dirLocation);
           }}
         >
-          <Folder />
+          {state.isDirOpened(dirLocation) ? <FolderTwoTone /> : <FolderOpenTwoTone />}
           {name}
         </button>
         <NodesView tree={content} location={dirLocation} state={state} />

--- a/ui/src/components/FileTreeView/FileTreeView.types.ts
+++ b/ui/src/components/FileTreeView/FileTreeView.types.ts
@@ -23,3 +23,20 @@ export type TreeState = {
   openedFile: NodeAbsoluteLocation;
   openFile: (loc: NodeAbsoluteLocation) => void;
 };
+
+export function getAllDirectories(prefix: string[], files: FileTreeNode[]): string[][] {
+  const dirs: string[][] = [];
+  files
+    .filter(isDirectory)
+    .map(file => file as DirNode)
+    .forEach(dir => {
+      const newPrefix = [...prefix, dir.name];
+      dirs.push(newPrefix);
+      dirs.push(...getAllDirectories(newPrefix, dir.content));
+    });
+  return dirs;
+}
+
+const isDirectory = (node: FileTreeNode): boolean => {
+  return node.type === 'directory';
+};

--- a/ui/src/pages/PreviewStarterPage/PreviewStarterPage.component.tsx
+++ b/ui/src/pages/PreviewStarterPage/PreviewStarterPage.component.tsx
@@ -1,5 +1,11 @@
 import { Box, Grid } from '@mui/material';
-import { FileTree, FileTreeView, RootNodeLocation } from '../../components/FileTreeView';
+import {
+  FileTree,
+  FileTreeView,
+  getAllDirectories,
+  NodeAbsoluteLocation,
+  RootNodeLocation,
+} from '../../components/FileTreeView';
 import { useContext, useEffect, useState } from 'react';
 import { FileContentView } from '../../components/FileContentView';
 import { useNavigate } from 'react-router-dom';
@@ -26,6 +32,24 @@ export function PreviewStarterPage() {
       call(() => doRequestPreview(formData, setFiles));
     }
   }, [formData, navigate, call]);
+
+  // function references were introduced so that 'useCallback' can depend on them
+  const openFileRef = treeState.openFile;
+  const toggleDirRef = treeState.toggleDir;
+  useEffect(() => {
+    if (files !== undefined) {
+      // open up all 'src' dirs
+      getAllDirectories([], files)
+        .filter(slug => slug.length > 0 && slug[0] === 'src')
+        .forEach(dir => toggleDirRef(new NodeAbsoluteLocation(...dir)));
+
+      // select 'Main.scala' file
+      if (formData !== undefined) {
+        const mainScalaPath = ['src', 'main', 'scala', ...formData.groupId.split('.'), 'Main.scala'];
+        openFileRef(new NodeAbsoluteLocation(...mainScalaPath));
+      }
+    }
+  }, [files, formData, openFileRef, toggleDirRef]);
 
   // 92.5px is the height of buttons panel.
   return (

--- a/ui/src/pages/PreviewStarterPage/PreviewStarterPage.component.tsx
+++ b/ui/src/pages/PreviewStarterPage/PreviewStarterPage.component.tsx
@@ -31,12 +31,12 @@ export function PreviewStarterPage() {
   return (
     <>
       <Grid container style={{ height: 'calc(100% - 92.5px)' }}>
-        <Grid item xs={3} className={classes.fullHeight}>
+        <Grid item xs={2.2} className={classes.fullHeight}>
           <Box className={cx(classes.fullHeight, classes.treeViewContainer)}>
             <FileTreeView tree={files} location={RootNodeLocation} state={treeState} />
           </Box>
         </Grid>
-        <Grid item xs={9} className={classes.fullHeight}>
+        <Grid item xs={9.8} className={classes.fullHeight}>
           <Box className={cx(classes.fullHeight, classes.fileViewContainer)}>
             <FileContentView files={files} opened={treeState.openedFile} />
           </Box>

--- a/ui/src/pages/RootPage/RootPage.styles.ts
+++ b/ui/src/pages/RootPage/RootPage.styles.ts
@@ -9,14 +9,14 @@ export const useStyles = makeStyles()(theme => ({
   configurationWrapper: {
     height: '92%',
     backgroundColor: theme.palette.neutral.main,
-    padding: theme.spacing(8, 3),
+    padding: theme.spacing(7, 3),
 
     [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing(8, 10),
+      padding: theme.spacing(7, 5),
     },
 
     [theme.breakpoints.up('xl')]: {
-      padding: theme.spacing(8, 16),
+      padding: theme.spacing(7, 8),
     },
   },
 


### PR DESCRIPTION
The following improvements were added:
* _preview_ layout was improved to offer more space for the editor (files tree was narrowed, code editor was expanded, margins got thinner)
* all `src` folders are opened
* `Main.scala` file content is selected in the editor
* folder representation was modified to slightly visually distinguish between folder closed/opened states

Here is the look & feel of `preview`:
<img width="1448" alt="image" src="https://user-images.githubusercontent.com/3641082/190375724-f7d658a0-d6ec-4983-8f16-1d543a75684d.png">

Closes #170