### PR TITLE
feat: add label to distinguish generate ZIP/preview operations in metric

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/content/ContentService.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/content/ContentService.scala
@@ -1,6 +1,7 @@
 package com.softwaremill.adopttapir.starter.content
 
 import cats.effect.IO
+import com.softwaremill.adopttapir.metrics.Metrics
 import com.softwaremill.adopttapir.starter.StarterDetails
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
 import com.softwaremill.adopttapir.template.ProjectGenerator
@@ -19,6 +20,7 @@ class ContentService(projectGenerator: ProjectGenerator, generatedFilesFormatter
         DirectoryMerger(projectName, paths, content)
       }))
       projectAsTree <- IO(projectAsDirTrees.reduce(DirectoryMerger.apply))
+      _ <- IO(Metrics.increasePreviewOperationMetricCounter(starterDetails))
     } yield projectAsTree
   }
 }


### PR DESCRIPTION
At present preview is not reported as a metric. Add _operation_ label to the existing _adopt_tapir_starter_generated_total_ metric. It can contain the following values `preview` and `generate`. As a result both `preview` and `generate` operations can be independently tracked.

Part of #175