### PR TITLE
feat: enable 'preview' button in the embedded form

### DIFF
--- a/ui/src/api/starter.ts
+++ b/ui/src/api/starter.ts
@@ -42,10 +42,9 @@ export type StarterRequest = {
   builder: Builder;
 };
 
+export const serverAddress = process.env.REACT_APP_SERVER_ADDRESS ?? 'https://adopt-tapir.softwaremill.com';
+
 export async function doRequestStarter(formData: StarterRequest) {
-  const serverAddress = !process.env.REACT_APP_SERVER_ADDRESS
-    ? 'https://adopt-tapir.softwaremill.com'
-    : process.env.REACT_APP_SERVER_ADDRESS;
   const response = await fetch(`${serverAddress}/api/v1/starter.zip`, {
     method: 'POST',
     headers: {

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -4,7 +4,14 @@ import ShareTwoToneIcon from '@mui/icons-material/ShareTwoTone';
 import { FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { DevTool } from '@hookform/devtools';
-import { Builder, doRequestStarter, JSONImplementation, ScalaVersion, StarterRequest } from 'api/starter';
+import {
+  Builder,
+  doRequestStarter,
+  JSONImplementation,
+  ScalaVersion,
+  serverAddress,
+  StarterRequest,
+} from 'api/starter';
 import { useApiCall } from 'hooks/useApiCall';
 import { isDevelopment } from 'consts/env';
 import { FormTextField } from '../FormTextField';
@@ -70,8 +77,8 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
         // Conversion of bools is done by hand, because casting writes booleans as strings.
         const formData: StarterRequest = {
           ...casted,
-          addDocumentation: 'true' === casted.addDocumentation.toString(),
-          addMetrics: 'true' === casted.addMetrics.toString(),
+          addDocumentation: JSON.parse(casted.addDocumentation.toString()),
+          addMetrics: JSON.parse(casted.addMetrics.toString()),
         };
         contextDispatch(setFormData(formData));
         navigate('/preview-starter');
@@ -159,6 +166,15 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
     );
     await navigator.clipboard.writeText(urlToShare);
     setSnackbar({ open: true, severity: 'info', message: 'Link to configuration copied to clipboard.' });
+  };
+
+  const handleShowPreviewInNewTab = () => {
+    const casted = form.getValues() as StarterRequest;
+    const urlToShare = stringifyUrl(
+      { url: serverAddress, query: { ...casted, preview: 'true' } },
+      { skipNull: true, skipEmptyString: true }
+    );
+    window.open(urlToShare, '_blank');
   };
 
   return (
@@ -256,19 +272,17 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
               Reset
             </Button>
 
-            {!isEmbedded && (
-              <Button
-                className={classes.submitButton}
-                onClick={handleShowPreview}
-                variant="contained"
-                color="primary"
-                size="medium"
-                type="button"
-                disableElevation
-              >
-                Preview
-              </Button>
-            )}
+            <Button
+              className={classes.submitButton}
+              onClick={isEmbedded ? handleShowPreviewInNewTab : handleShowPreview}
+              variant="contained"
+              color="primary"
+              size="medium"
+              type="button"
+              disableElevation
+            >
+              Preview
+            </Button>
 
             <Button
               className={classes.submitButton}

--- a/ui/src/hooks/useSharedConfig.ts
+++ b/ui/src/hooks/useSharedConfig.ts
@@ -5,11 +5,12 @@ import { StarterRequest } from '../api/starter';
 import { SnackbarConfig } from '../components/CommonSnackbar';
 import { useSearchParams } from 'react-router-dom';
 
-export function useSharedConfig(): [StarterRequest | undefined, SnackbarConfig | undefined, boolean] {
+export function useSharedConfig(): [StarterRequest | undefined, SnackbarConfig | undefined, boolean, boolean] {
   const [searchParams, setSearchParams] = useSearchParams();
   const [request, setRequest] = useState<StarterRequest>();
   const [snackbar, setSnackbar] = useState<SnackbarConfig>();
   const [ready, setReady] = useState(false);
+  const [preview, setPreview] = useState(false);
 
   useEffect(() => {
     if (searchParams.toString() === '') {
@@ -17,16 +18,20 @@ export function useSharedConfig(): [StarterRequest | undefined, SnackbarConfig |
       return;
     }
     const params = parse(searchParams.toString(), { parseBooleans: true });
+    const shouldPreview = 'preview' in params;
+    setPreview(shouldPreview);
     starterValidationSchema
       .isValid(params)
       .then(isValid => {
         if (isValid) {
           setRequest(params as StarterRequest);
-          setSnackbar({
-            open: true,
-            severity: 'info',
-            message: 'Linked configuration was applied.',
-          });
+          if (!shouldPreview) {
+            setSnackbar({
+              open: true,
+              severity: 'info',
+              message: 'Linked configuration was applied.',
+            });
+          }
         } else {
           setSnackbar({
             open: true,
@@ -48,5 +53,5 @@ export function useSharedConfig(): [StarterRequest | undefined, SnackbarConfig |
     setSearchParams({});
   }, [searchParams, setSearchParams]);
 
-  return [request, snackbar, ready];
+  return [request, snackbar, ready, preview];
 }


### PR DESCRIPTION
Note that clicking the `preview` button in the embedded form mode results in:
* generation of URL that contains the current configuration as query params with an extra `preview=true` parameter added
* opening of the URL in question in the new window
* configuration application followed by the switch to `preview` mode

Closes #169 