### PR TITLE
feat: trigger form validation on 'Preview' in embedded mode

### DIFF
--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -169,12 +169,17 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
   };
 
   const handleShowPreviewInNewTab = () => {
-    const casted = form.getValues() as StarterRequest;
-    const urlToShare = stringifyUrl(
-      { url: serverAddress, query: { ...casted, preview: 'true' } },
-      { skipNull: true, skipEmptyString: true }
-    );
-    window.open(urlToShare, '_blank');
+    // 'trigger()' triggers the validation.
+    form.trigger().then(isValid => {
+      if (isValid) {
+        const casted = form.getValues() as StarterRequest;
+        const urlToShare = stringifyUrl(
+          { url: serverAddress, query: { ...casted, preview: 'true' } },
+          { skipNull: true, skipEmptyString: true }
+        );
+        window.open(urlToShare, '_blank');
+      }
+    });
   };
 
   return (


### PR DESCRIPTION
When `Preview` is selected in the embedded mode issue the form validation prior proceeding further so that invalid configuration doesn't result in preview with defaults.

Follow-up to #169