### PR TITLE
fix: update `.mergify.yml` rules to reflect the recent CI changes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,14 +6,16 @@ pull_request_rules:
   - name: automatic merge for softwaremill-ci pull requests affecting build.sbt
     conditions:
       - author=softwaremill-ci
-      - check-success=verify (Scala2, No)
-      - check-success=verify (Scala2, Circe)
-      - check-success=verify (Scala2, Jsoniter)
-      - check-success=verify (Scala2, ZIOJson)
-      - check-success=verify (Scala3, No)
-      - check-success=verify (Scala3, Circe)
-      - check-success=verify (Scala3, Jsoniter)
-      - check-success=verify (Scala3, ZIOJson)
+      - check-success=verify_unit_tests_lint
+      - check-success=verify_integration (Scala2, No)
+      - check-success=verify_integration (Scala2, Circe)
+      - check-success=verify_integration (Scala2, Jsoniter)
+      - check-success=verify_integration (Scala2, ZIOJson)
+      - check-success=verify_integration (Scala3, No)
+      - check-success=verify_integration (Scala3, Circe)
+      - check-success=verify_integration (Scala3, Jsoniter)
+      - check-success=verify_integration (Scala3, ZIOJson)
+      - check-success=verify_docker_image_build
       - "#files=1"
       - files=build.sbt
     actions:
@@ -22,14 +24,16 @@ pull_request_rules:
   - name: automatic merge for softwaremill-ci pull requests affecting project plugins.sbt
     conditions:
       - author=softwaremill-ci
-      - check-success=verify (Scala2, No)
-      - check-success=verify (Scala2, Circe)
-      - check-success=verify (Scala2, Jsoniter)
-      - check-success=verify (Scala2, ZIOJson)
-      - check-success=verify (Scala3, No)
-      - check-success=verify (Scala3, Circe)
-      - check-success=verify (Scala3, Jsoniter)
-      - check-success=verify (Scala3, ZIOJson)
+      - check-success=verify_unit_tests_lint
+      - check-success=verify_integration (Scala2, No)
+      - check-success=verify_integration (Scala2, Circe)
+      - check-success=verify_integration (Scala2, Jsoniter)
+      - check-success=verify_integration (Scala2, ZIOJson)
+      - check-success=verify_integration (Scala3, No)
+      - check-success=verify_integration (Scala3, Circe)
+      - check-success=verify_integration (Scala3, Jsoniter)
+      - check-success=verify_integration (Scala3, ZIOJson)
+      - check-success=verify_docker_image_build
       - "#files=1"
       - files=project/plugins.sbt
     actions:
@@ -38,14 +42,16 @@ pull_request_rules:
   - name: semi-automatic merge for softwaremill-ci pull requests
     conditions:
       - author=softwaremill-ci
-      - check-success=verify (Scala2, No)
-      - check-success=verify (Scala2, Circe)
-      - check-success=verify (Scala2, Jsoniter)
-      - check-success=verify (Scala2, ZIOJson)
-      - check-success=verify (Scala3, No)
-      - check-success=verify (Scala3, Circe)
-      - check-success=verify (Scala3, Jsoniter)
-      - check-success=verify (Scala3, ZIOJson)
+      - check-success=verify_unit_tests_lint
+      - check-success=verify_integration (Scala2, No)
+      - check-success=verify_integration (Scala2, Circe)
+      - check-success=verify_integration (Scala2, Jsoniter)
+      - check-success=verify_integration (Scala2, ZIOJson)
+      - check-success=verify_integration (Scala3, No)
+      - check-success=verify_integration (Scala3, Circe)
+      - check-success=verify_integration (Scala3, Jsoniter)
+      - check-success=verify_integration (Scala3, ZIOJson)
+      - check-success=verify_docker_image_build
       - "#approved-reviews-by>=1"
     actions:
       merge:
@@ -53,14 +59,16 @@ pull_request_rules:
   - name: automatic merge for softwaremill-ci pull requests affecting project build.properties
     conditions:
       - author=softwaremill-ci
-      - check-success=verify (Scala2, No)
-      - check-success=verify (Scala2, Circe)
-      - check-success=verify (Scala2, Jsoniter)
-      - check-success=verify (Scala2, ZIOJson)
-      - check-success=verify (Scala3, No)
-      - check-success=verify (Scala3, Circe)
-      - check-success=verify (Scala3, Jsoniter)
-      - check-success=verify (Scala3, ZIOJson)
+      - check-success=verify_unit_tests_lint
+      - check-success=verify_integration (Scala2, No)
+      - check-success=verify_integration (Scala2, Circe)
+      - check-success=verify_integration (Scala2, Jsoniter)
+      - check-success=verify_integration (Scala2, ZIOJson)
+      - check-success=verify_integration (Scala3, No)
+      - check-success=verify_integration (Scala3, Circe)
+      - check-success=verify_integration (Scala3, Jsoniter)
+      - check-success=verify_integration (Scala3, ZIOJson)
+      - check-success=verify_docker_image_build
       - "#files=1"
       - files=project/build.properties
     actions:
@@ -69,14 +77,16 @@ pull_request_rules:
   - name: automatic merge for softwaremill-ci pull requests affecting .scalafmt.conf
     conditions:
       - author=softwaremill-ci
-      - check-success=verify (Scala2, No)
-      - check-success=verify (Scala2, Circe)
-      - check-success=verify (Scala2, Jsoniter)
-      - check-success=verify (Scala2, ZIOJson)
-      - check-success=verify (Scala3, No)
-      - check-success=verify (Scala3, Circe)
-      - check-success=verify (Scala3, Jsoniter)
-      - check-success=verify (Scala3, ZIOJson)
+      - check-success=verify_unit_tests_lint
+      - check-success=verify_integration (Scala2, No)
+      - check-success=verify_integration (Scala2, Circe)
+      - check-success=verify_integration (Scala2, Jsoniter)
+      - check-success=verify_integration (Scala2, ZIOJson)
+      - check-success=verify_integration (Scala3, No)
+      - check-success=verify_integration (Scala3, Circe)
+      - check-success=verify_integration (Scala3, Jsoniter)
+      - check-success=verify_integration (Scala3, ZIOJson)
+      - check-success=verify_docker_image_build
       - "#files=1"
       - files=.scalafmt.conf
     actions:


### PR DESCRIPTION
When new jobs/steps were introduced the existing ones were renamed. As a result `mergify` was no longer able to evalute the rules. Update rules to reflect new job names.

Follow-up to #197