### PR TITLE
feat: tune the generated Scala CLI project according to the guidelines

### DIFF
--- a/backend/src/main/resources/template/README_scala-cli.md
+++ b/backend/src/main/resources/template/README_scala-cli.md
@@ -10,6 +10,9 @@ scala-cli run . # run the application (Main)
 scala-cli fmt --check . # run scalaformat check on all scala files and print summary, removing '--check' fixes badly formatted files
 ```
 
+To open project in the IDE (Metals / IntelliJ) run any of the `compile` or `test` command above and open the project.
+IDE should detect a BSP project and import it.
+
 Alternatively, you can use Scala CLI via a docker image:
 
 ```shell

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
@@ -142,7 +142,7 @@ object BuildSbtView extends BuildView {
 
 object BuildScalaCliView extends BuildView {
   def format(dependencies: List[Dependency]): String = {
-    val importPrefix = "using lib "
+    val importPrefix = "//> using lib "
     dependencies
       .map(_.asScalaCliDependency)
       .mkString(importPrefix, System.lineSeparator() + importPrefix, System.lineSeparator())

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
@@ -201,12 +201,12 @@ private object ScalaCliProjectTemplate extends ProjectTemplate {
         (BuildScalaCliView.getMainDependencies _).andThen(BuildScalaCliView.format)(starterDetails)
       )
       .toString()
-    GeneratedFile("build.sc", content)
+    GeneratedFile("build.scala", content)
   }
 
   private def getTestScalaCli(starterDetails: StarterDetails): GeneratedFile = {
     val content = (BuildScalaCliView.getAllTestDependencies _).andThen(BuildScalaCliView.format)(starterDetails)
-    GeneratedFile("src/test/scala/test.sc", content)
+    GeneratedFile("src/test/scala/build.test.scala", content)
   }
 
   private lazy val readme: GeneratedFile =

--- a/backend/src/main/twirl/scalaCliBuild.scala.txt
+++ b/backend/src/main/twirl/scalaCliBuild.scala.txt
@@ -4,9 +4,9 @@ groupId: String,
 scalaVersion: String,
 dependencies: String
 )
-using publish.organization "@groupId"
-using publish.name "@name"
-using publish.version "0.1.0-SNAPSHOT"
+//> using publish.organization "@groupId"
+//> using publish.name "@name"
+//> using publish.version "0.1.0-SNAPSHOT"
 
-using scala "@scalaVersion"
+//> using scala "@scalaVersion"
 @dependencies

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
@@ -53,8 +53,8 @@ class StarterApiTest extends BaseTest with TestDependencies {
     response.code.code shouldBe 200
     checkStreamZipContent(response.body) { unpackedDir =>
       unpackedDir.listRecursively.toList.filter(_.isRegularFile).map(_.path.getFileName.toString) should contain theSameElementsAs List(
-        "build.sc",
-        "test.sc",
+        "build.scala",
+        "build.test.scala",
         ".scalafmt.conf",
         "EndpointsSpec.scala",
         "Endpoints.scala",
@@ -77,7 +77,9 @@ class StarterApiTest extends BaseTest with TestDependencies {
       checkStreamZipContent(response.body) { unpackedDir =>
         val paths = unpackedDir.listRecursively.toList
           .collect {
-            case f: File if f.path.toString.endsWith(".scala") && f.isRegularFile =>
+            case f: File
+                if f.path.toString.endsWith(".scala") && !f.path
+                  .endsWith("build.scala") && !f.path.endsWith("build.test.scala") && f.isRegularFile =>
               unpackedDir.relativize(f)
           }
         paths.map(_.toString) should contain theSameElementsAs List(


### PR DESCRIPTION
The following suggestions were implemented:
* entry about importing Scala CLI project to popular IDEs (Metals / IntelliJ) was added to the generated `README.md`
* project files (`*.sc`) were renamed to `*.scala` so that IDEs are not confused, what is more `test.sc` was renamed to `build.test.scala` to better reflect its intent
* comment-based `using` notation is used in the generated project files as it is the recommended way of doing it

Note that `.gitignore` was not introduced as it is a good candidate for both `Build tools` and as such will be added as a part of separate PR.

Part of #194 