### PR TITLE
feat: generate '.gitignore' file for IntelliJ / Metals IDEs

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
@@ -127,7 +127,7 @@ abstract class ProjectTemplate {
 
 object SbtProjectTemplate extends ProjectTemplate {
   override def generate(starterDetails: StarterDetails): List[GeneratedFile] =
-    super.generate(starterDetails) ::: List(getBuildSbt(starterDetails), buildProperties, pluginsSbt, sbtx, readme)
+    super.generate(starterDetails) ::: List(getBuildSbt(starterDetails), buildProperties, pluginsSbt, sbtx, readme, gitignore)
 
   lazy val sbtxFile = "sbtx"
 
@@ -158,6 +158,9 @@ object SbtProjectTemplate extends ProjectTemplate {
 
   private lazy val readme: GeneratedFile =
     GeneratedFile(CommonObjectTemplate.readMePath, CommonObjectTemplate.templateResource("README_sbt.md"))
+
+  private lazy val gitignore: GeneratedFile =
+    GeneratedFile(".gitignore", txt.gitignore(List(".bloop", "target", "metals.sbt", "project/project")).toString())
 }
 
 object CommonObjectTemplate {
@@ -190,7 +193,7 @@ object CommonObjectTemplate {
 
 private object ScalaCliProjectTemplate extends ProjectTemplate {
   override def generate(starterDetails: StarterDetails): List[GeneratedFile] =
-    super.generate(starterDetails) ::: List(getBuildScalaCli(starterDetails), getTestScalaCli(starterDetails), readme)
+    super.generate(starterDetails) ::: List(getBuildScalaCli(starterDetails), getTestScalaCli(starterDetails), readme, gitignore)
 
   private def getBuildScalaCli(starterDetails: StarterDetails): GeneratedFile = {
     val content = txt
@@ -211,4 +214,6 @@ private object ScalaCliProjectTemplate extends ProjectTemplate {
 
   private lazy val readme: GeneratedFile =
     GeneratedFile(CommonObjectTemplate.readMePath, CommonObjectTemplate.templateResource("README_scala-cli.md"))
+
+  private lazy val gitignore: GeneratedFile = GeneratedFile(".gitignore", txt.gitignore(List(".bsp/", ".scala-build/")).toString())
 }

--- a/backend/src/main/twirl/gitignore.scala.txt
+++ b/backend/src/main/twirl/gitignore.scala.txt
@@ -1,0 +1,8 @@
+@(additionalIgnores: List[String])
+# common IDEs to be ignored
+.idea/
+.metals/
+.vscode/
+
+# build tool specific entries@for(additionalIgnore <- additionalIgnores){
+@additionalIgnore}

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
@@ -37,7 +37,8 @@ class StarterApiTest extends BaseTest with TestDependencies {
         "Endpoints.scala",
         "Main.scala",
         "sbtx",
-        "README.md"
+        "README.md",
+        ".gitignore"
       )
     }
   }
@@ -59,7 +60,8 @@ class StarterApiTest extends BaseTest with TestDependencies {
         "EndpointsSpec.scala",
         "Endpoints.scala",
         "Main.scala",
-        "README.md"
+        "README.md",
+        ".gitignore"
       )
     }
   }


### PR DESCRIPTION
Generate '.gitignore' file for both build tools (sbt and Scala CLI) that ignores IntelliJ and Metals IDEs project/support files.

Note that both build tools projects were tested under both IntelliJ and Metals to confirm if correct files are excluded from `Git` by:
* importing projects to both IntelliJ and Metals IDEs
* committing files according to the `.gitignore`
* checking if only source, build tool specific files were committed
* cloning and importing projects again

The `.gitignore` file content per build tool:
* _sbt_:
  ```
  # common IDEs to be ignored
  .idea/
  .metals/
  .vscode/
  
  # build tool specific entries
  .bloop
  target
  metals.sbt
  project/project
  ```
* _Scala CLI_:
  ```
  # common IDEs to be ignored
  .idea/
  .metals/
  .vscode/
  
  # build tool specific entries
  .bsp/
  .scala-build/
  ```

Closes #194