### PR TITLE
fix: reduce buttons padding to 14px

### DIFF
--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -19,6 +19,16 @@ const baseTheme = createTheme({
     },
     divider: 'rgba(0, 0, 0, 0.12)',
   },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        sizeMedium: {
+          paddingLeft: 14,
+          paddingRight: 14,
+        },
+      },
+    },
+  },
 });
 
 export const theme = responsiveFontSizes(baseTheme);


### PR DESCRIPTION
Issue: when embedded form is viewed under Safari it divides button into 2 lines.
![image](https://user-images.githubusercontent.com/3641082/194107806-8d314901-8ad4-4480-88f0-ed275310dcb8.png)

Solution: reduce the default padding from `16px` to `14px` so that they fit into one line.
![image](https://user-images.githubusercontent.com/3641082/194107935-0ed78b5a-7f5f-42cc-9f25-160e3cd739a5.png)

Follow-up to #169