### PR TITLE
fix: don't show double vertical scrollbars on sbtx file

### DIFF
--- a/ui/src/components/FileContentView/FileContentView.component.tsx
+++ b/ui/src/components/FileContentView/FileContentView.component.tsx
@@ -74,7 +74,6 @@ export function FileContentView({ files, opened }: Props) {
           backgroundColor: 'rgb(255, 255, 255)',
           padding: 0,
           height: '100%',
-          overflowY: 'auto',
         }}
         lineNumberStyle={{ minWidth: '44px' }}
         language={language}

--- a/ui/src/components/FileContentView/FileContentView.styles.ts
+++ b/ui/src/components/FileContentView/FileContentView.styles.ts
@@ -5,6 +5,7 @@ export const useStyles = makeStyles()(theme => {
     wrapper: {
       height: '100%',
       marginTop: 0,
+      overflow: 'auto',
     },
   };
 });

--- a/ui/src/components/FileTreeView/FileTreeView.styles.ts
+++ b/ui/src/components/FileTreeView/FileTreeView.styles.ts
@@ -33,7 +33,6 @@ export const useStyles = makeStyles<{ level: number }>()((theme, { level }) => {
       },
     },
     openedFile: {
-      fontWeight: 'bold',
       color: theme.palette.primary.dark,
       backgroundColor: theme.palette.primary.light,
       backgroundClip: 'padding-box',

--- a/ui/src/pages/PreviewStarterPage/PreviewStarterPage.component.tsx
+++ b/ui/src/pages/PreviewStarterPage/PreviewStarterPage.component.tsx
@@ -54,13 +54,13 @@ export function PreviewStarterPage() {
   // 92.5px is the height of buttons panel.
   return (
     <>
-      <Grid container style={{ height: 'calc(100% - 92.5px)' }}>
-        <Grid item xs={2.2} className={classes.fullHeight}>
+      <Grid container style={{ height: 'calc(100vh - (100vh * 0.08) - 150px)', minHeight: '450px' }}>
+        <Grid item xs={2.4} className={classes.fullHeight}>
           <Box className={cx(classes.fullHeight, classes.treeViewContainer)}>
             <FileTreeView tree={files} location={RootNodeLocation} state={treeState} />
           </Box>
         </Grid>
-        <Grid item xs={9.8} className={classes.fullHeight}>
+        <Grid item xs={9.6} className={classes.fullHeight}>
           <Box className={cx(classes.fullHeight, classes.fileViewContainer)}>
             <FileContentView files={files} opened={treeState.openedFile} />
           </Box>

--- a/ui/src/pages/PreviewStarterPage/PreviewStarterPage.styles.ts
+++ b/ui/src/pages/PreviewStarterPage/PreviewStarterPage.styles.ts
@@ -23,7 +23,7 @@ export const useStyles = makeStyles()(theme => ({
     display: 'flex',
     marginTop: theme.spacing(1),
     backgroundColor: 'white',
-    padding: theme.spacing(3),
+    padding: theme.spacing(2),
     border: '1px solid ' + theme.palette.divider,
     borderBottomLeftRadius: '4px',
     borderBottomRightRadius: '4px',

--- a/ui/src/pages/RootPage/RootPage.styles.ts
+++ b/ui/src/pages/RootPage/RootPage.styles.ts
@@ -9,14 +9,14 @@ export const useStyles = makeStyles()(theme => ({
   configurationWrapper: {
     height: '92%',
     backgroundColor: theme.palette.neutral.main,
-    padding: theme.spacing(7, 3),
+    padding: theme.spacing(5, 2),
 
     [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing(7, 5),
+      padding: theme.spacing(5, 3),
     },
 
     [theme.breakpoints.up('xl')]: {
-      padding: theme.spacing(7, 8),
+      padding: theme.spacing(5, 5),
     },
   },
 


### PR DESCRIPTION
According to [SO](https://stackoverflow.com/a/61844861) it was determined that the top container has to have
fixed height (could be `100vh` related but cannot be `100%` related) and
then inner container can have 100% height. Note that `minHeight` was set to `450px`.

Apart from the the following changes were applied
* all margins were reduced so that file/code areas use more screen
  estate
* selected file (in file view) is no longer bolded (but still
  highlighted so that there is no doubt that it is selected) so that it
  doesn't take more space
* proportion between file and content views was modified so that more
  space is available for file view (potentially reducing the need for
  horizontal scrollbar)

Here is the current look & feel for `1794px` width:
![image](https://user-images.githubusercontent.com/3641082/194550388-a6c26f26-b139-4b57-a9e4-6169890bfd88.png)

Closes #92