### PR TITLE
fix: prevent copying line numbers in Safari

### DIFF
--- a/ui/src/components/FileContentView/FileContentView.component.tsx
+++ b/ui/src/components/FileContentView/FileContentView.component.tsx
@@ -75,9 +75,17 @@ export function FileContentView({ files, opened }: Props) {
           padding: 0,
           height: '100%',
         }}
-        lineNumberStyle={{ minWidth: '44px' }}
+        lineNumberContainerStyle={{
+          float: 'left',
+          textAlign: 'right',
+          paddingRight: '1em',
+          minWidth: '44px',
+          userSelect: 'none',
+          WebkitUserSelect: 'none'
+        }}
         language={language}
         showLineNumbers={true}
+        showInlineLineNumbers={false}
         style={a11yLight}
       >
         {content}

--- a/ui/src/components/FileContentView/FileContentView.component.tsx
+++ b/ui/src/components/FileContentView/FileContentView.component.tsx
@@ -81,7 +81,7 @@ export function FileContentView({ files, opened }: Props) {
           paddingRight: '1em',
           minWidth: '44px',
           userSelect: 'none',
-          WebkitUserSelect: 'none'
+          WebkitUserSelect: 'none',
         }}
         language={language}
         showLineNumbers={true}


### PR DESCRIPTION
In **SyntaxHighlighter** component:
if we set `showInlineLineNumbers` property to `false`, numbers will be shown in a separate element.
When styled accordingly, it will be no different than what we have now:

<img width="689" alt="Screenshot 2022-10-10 at 13 14 20" src="https://user-images.githubusercontent.com/27156596/194854716-53e5aca4-4526-4739-8cb0-3224d763a97f.png">

Checked on Safari, Chrome, Firefox and Opera.

Fixes #193 