### PR TITLE
fix: highlight of opened file in preview's tree view

### DIFF
--- a/ui/src/components/FileTreeView/FileTreeView.styles.ts
+++ b/ui/src/components/FileTreeView/FileTreeView.styles.ts
@@ -3,6 +3,7 @@ import { makeStyles } from 'tss-react/mui';
 export const useStyles = makeStyles<{ level: number }>()((theme, { level }) => {
   return {
     wrapper: {
+      display: 'flex',
       height: '100%',
       overflow: 'auto',
     },


### PR DESCRIPTION
Before:
<img width="211" alt="Screenshot 2022-10-10 at 16 57 06" src="https://user-images.githubusercontent.com/27156596/194895577-255a8730-fb81-48bd-874f-753195443c31.png">

After:
<img width="273" alt="Screenshot 2022-10-10 at 16 44 37" src="https://user-images.githubusercontent.com/27156596/194895352-ce11c508-40c4-40ae-8d34-5228078159e5.png">

Part of/fix for #219 