### PR TITLE
fix: switch to vertx server backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,11 +25,9 @@ val logbackClassicVersion = "1.4.4"
 val scalaTestVersion = "3.2.14"
 
 val httpDependencies = Seq(
-  "org.http4s" %% "http4s-blaze-server" % http4sBlazeServerVersion,
-  "org.http4s" %% "http4s-circe" % http4sCirceVersion,
   "com.softwaremill.sttp.client3" %% "async-http-client-backend-fs2" % sttpVersion,
   "com.softwaremill.sttp.client3" %% "slf4j-backend" % sttpVersion,
-  "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-vertx-server-cats" % tapirVersion,
   "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % tapirVersion
 )
 


### PR DESCRIPTION
There issue with non-deterministic EOF is observable by others but so far there is no good explanation (or test method) given (see [#668)](https://github.com/http4s/blaze/issues/668) therefore for the time being we are switching to vertx http server.

TODO:
* `OPTIONS` request
  ```shell
  curl -v 'http://localhost:9090/api/v1/content' \
  -X 'OPTIONS' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Access-Control-Request-Headers: content-type' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Connection: keep-alive' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36' \
  --compressed
  ```
  is not accepted and results in `405 Method Not Allowed` therefore UI is not able to talk to the server but calling `curl`
  ```shell
  curl -v 'http://localhost:9090/api/v1/content' \
    -H 'Referer: http://localhost:3000/' \
    -H 'Sec-Fetch-Dest: empty' \
    -H 'Sec-Fetch-Mode: cors' \
    -H 'Sec-Fetch-Site: same-site' \
    -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36' \
    -H 'sec-ch-ua: "Chromium";v="106", "Google Chrome";v="106", "Not;A=Brand";v="99"' \
    --data-raw '{"addDocumentation":false,"addMetrics":false,"projectName":"clear-buzzard","groupId":"com.softwaremill","json":"No","scalaVersion":"Scala3","builder":"Sbt","effect":"IOEffect","implementation":"Http4s"}' \
    --compressed
  ```
* at the moment one cannot customise the logs hence they are not displayed when the server is started

Verifies #49