### PR TITLE
chore: unify CI/CD images to run on the same ubuntu version

### DIFF
--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -95,7 +95,7 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     needs: [ verify_unit_tests_lint, verify_integration ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check-out repository


### PR DESCRIPTION
Despite [docs](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/) it seems that `ubuntu-latest` is still `20.04` hence run all actions on the specific, `22.04` version.