### PR TITLE
Fixing no spaces between sentences in generated code

### DIFF
--- a/backend/src/main/twirl/MainFutureNetty.scala.txt
+++ b/backend/src/main/twirl/MainFutureNetty.scala.txt
@@ -19,7 +19,7 @@ object Main {
     val program = for {
       binding <- NettyFutureServer(@if(addMetrics) {serverOptions}).port(port).addEndpoints(Endpoints.all).start()
       _ <- Future {
-        println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI.}else{Server started at http://localhost:${binding.port}.} Press ENTER key to exit.")
+        println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${binding.port}. }Press ENTER key to exit.")
         StdIn.readLine()
       }
       stop <- binding.stop()

--- a/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
@@ -19,7 +19,7 @@ import ExecutionContext.Implicits.global
     for
       binding <- NettyFutureServer(@if(addMetrics) {serverOptions}).port(port).addEndpoints(Endpoints.all).start()
       _ <- Future {
-        println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI.}else{Server started at http://localhost:${binding.port}.} Press ENTER key to exit.")
+        println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${binding.port}. }Press ENTER key to exit.")
         StdIn.readLine()
       }
       stop <- binding.stop()

--- a/backend/src/main/twirl/MainIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4s.scala.txt
@@ -28,7 +28,7 @@ object Main extends IOApp {
       .withHttpApp(Router("/" -> routes).orNotFound)
       .resource
       .use { server => IO.blocking {
-         println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI.}else{Server started at http://localhost:${server.address.getPort}.} Press ENTER key to exit.")
+         println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
          StdIn.readLine()
          }
       }

--- a/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
@@ -28,7 +28,7 @@ object Main extends IOApp:
       .withHttpApp(Router("/" -> routes).orNotFound)
       .resource
       .use { server => IO.blocking {
-         println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI.}else{Server started at http://localhost:${server.address.getPort}.} Press ENTER key to exit.")
+         println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
          StdIn.readLine()
          }
       }

--- a/backend/src/main/twirl/MainIONetty.scala.txt
+++ b/backend/src/main/twirl/MainIONetty.scala.txt
@@ -31,7 +31,7 @@ object Main extends IOApp {
             .addEndpoints(Endpoints.all)
             .start()
           _ <- IO.blocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI.}else{Server started at http://localhost:${bind.port}.} Press ENTER key to exit.")
+            println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.port}. }Press ENTER key to exit.")
             StdIn.readLine()
           }
           _ <- bind.stop()

--- a/backend/src/main/twirl/MainIONettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainIONettyScala3.scala.txt
@@ -30,7 +30,7 @@ object Main extends IOApp:
             .addEndpoints(Endpoints.all)
             .start()
           _ <- IO.blocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI.}else{Server started at http://localhost:${bind.port}.} Press ENTER key to exit.")
+            println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.port}. }Press ENTER key to exit.")
             StdIn.readLine()
           }
           _ <- bind.stop()

--- a/backend/src/main/twirl/MainZIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4s.scala.txt
@@ -32,7 +32,7 @@ object Main extends ZIOAppDefault {
         .resource
         .use { server =>
           ZIO.succeedBlocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI.}else{Server started at http://localhost:${server.address.getPort}.} Press ENTER key to exit.")
+            println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
             StdIn.readLine()
           }
         }.unit

--- a/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
@@ -32,7 +32,7 @@ object Main extends ZIOAppDefault:
         .resource
         .use { server =>
           ZIO.succeedBlocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI.}else{Server started at http://localhost:${server.address.getPort}.} Press ENTER key to exit.")
+            println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
             StdIn.readLine()
           }
         }.unit

--- a/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
@@ -30,7 +30,7 @@ object Main extends ZIOAppDefault {
 
     (for {
       serverStart <- Server(app).withPort(port).make
-      _ <- Console.printLine(s"@if(addDocumentation){Go to http://localhost:${serverStart.port}/docs to open SwaggerUI.}else{Server started at http://localhost:${serverStart.port}.} Press ENTER key to exit.")
+      _ <- Console.printLine(s"@if(addDocumentation){Go to http://localhost:${serverStart.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${serverStart.port}. }Press ENTER key to exit.")
       _ <- Console.readLine
     } yield serverStart)
       .provideSomeLayer(EventLoopGroup.auto(0) ++ ServerChannelFactory.auto ++ Scope.default)

--- a/backend/src/main/twirl/MainZIOhttpZIOScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIOScala3.scala.txt
@@ -30,7 +30,7 @@ object Main extends ZIOAppDefault:
 
     (for
       serverStart <- Server(app).withPort(port).make
-      _ <- Console.printLine(s"@if(addDocumentation){Go to http://localhost:${serverStart.port}/docs to open SwaggerUI.}else{Server started at http://localhost:${serverStart.port}.} Press ENTER key to exit.")
+      _ <- Console.printLine(s"@if(addDocumentation){Go to http://localhost:${serverStart.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${serverStart.port}. }Press ENTER key to exit.")
       _ <- Console.readLine
     yield serverStart)
       .provideSomeLayer(EventLoopGroup.auto(0) ++ ServerChannelFactory.auto ++ Scope.default)


### PR DESCRIPTION
Added spaces in the `@if/ else` section of code templates, thus fixing the issue.