### PR TITLE
Refactor templates for cats and zio

### DIFF
--- a/backend/src/main/twirl/MainFutureNetty.scala.txt
+++ b/backend/src/main/twirl/MainFutureNetty.scala.txt
@@ -15,7 +15,7 @@ object Main {
       .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
       .options
     }
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
     val program = for {
       binding <- NettyFutureServer(@if(addMetrics) {serverOptions}).port(port).addEndpoints(Endpoints.all).start()
       _ <- Future {

--- a/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
@@ -14,7 +14,7 @@ import ExecutionContext.Implicits.global
     .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
     .options
   }
-  val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+  val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
   val program =
     for
       binding <- NettyFutureServer(@if(addMetrics) {serverOptions}).port(port).addEndpoints(Endpoints.all).start()

--- a/backend/src/main/twirl/MainFutureVertx.scala.txt
+++ b/backend/src/main/twirl/MainFutureVertx.scala.txt
@@ -19,7 +19,7 @@ object Main {
       .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
       .options
     }
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     val vertx = Vertx.vertx()
     val server = vertx.createHttpServer()

--- a/backend/src/main/twirl/MainFutureVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainFutureVertxScala3.scala.txt
@@ -18,7 +18,7 @@ import scala.io.StdIn
     .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
     .options
   }
-  val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+  val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
   val vertx = Vertx.vertx()
   val server = vertx.createHttpServer()

--- a/backend/src/main/twirl/MainIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4s.scala.txt
@@ -6,8 +6,6 @@ import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Router
 import sttp.tapir.server.http4s.@if(addMetrics){{Http4sServerInterpreter, Http4sServerOptions}}else{Http4sServerInterpreter}
 
-import scala.io.StdIn
-
 object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
@@ -21,16 +19,17 @@ object Main extends IOApp {
     val routes = Http4sServerInterpreter[IO]().toRoutes(Endpoints.all)
     }
 
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     BlazeServerBuilder[IO]
       .bindHttp(port, "localhost")
       .withHttpApp(Router("/" -> routes).orNotFound)
       .resource
-      .use { server => IO.blocking {
-         println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
-         StdIn.readLine()
-         }
+      .use { server =>
+        for {
+          _ <- IO.println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
+          _ <- IO.readLine
+        } yield ()
       }
       .as(ExitCode.Success)
   }

--- a/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
@@ -6,8 +6,6 @@ import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.Router
 import sttp.tapir.server.http4s.@if(addMetrics){{Http4sServerInterpreter, Http4sServerOptions}}else{Http4sServerInterpreter}
 
-import scala.io.StdIn
-
 object Main extends IOApp:
 
   override def run(args: List[String]): IO[ExitCode] =
@@ -21,15 +19,16 @@ object Main extends IOApp:
     val routes = Http4sServerInterpreter[IO]().toRoutes(Endpoints.all)
     }
 
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     BlazeServerBuilder[IO]
       .bindHttp(port, "localhost")
       .withHttpApp(Router("/" -> routes).orNotFound)
       .resource
-      .use { server => IO.blocking {
-         println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
-         StdIn.readLine()
-         }
+      .use { server =>
+        for {
+          _ <- IO.println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
+          _ <- IO.readLine
+        } yield ()
       }
       .as(ExitCode.Success)

--- a/backend/src/main/twirl/MainIONetty.scala.txt
+++ b/backend/src/main/twirl/MainIONetty.scala.txt
@@ -6,12 +6,11 @@ import cats.effect.{ExitCode, IO, IOApp}
 import sttp.tapir.server.netty.cats.@if(addMetrics){{NettyCatsServer, NettyCatsServerOptions}}else{NettyCatsServer}
 
 @if(addMetrics){import java.net.InetSocketAddress}
-import scala.io.StdIn
 
 object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     @if(addMetrics){
       Dispatcher[IO].map( d => { NettyCatsServer.apply[IO, InetSocketAddress]({
@@ -30,10 +29,8 @@ object Main extends IOApp {
             .host("localhost")
             .addEndpoints(Endpoints.all)
             .start()
-          _ <- IO.blocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.port}. }Press ENTER key to exit.")
-            StdIn.readLine()
-          }
+          _ <- IO.println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.port}. }Press ENTER key to exit.")
+          _ <- IO.readLine
           _ <- bind.stop()
         } yield bind
       }

--- a/backend/src/main/twirl/MainIONettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainIONettyScala3.scala.txt
@@ -6,10 +6,9 @@ import cats.effect.{ExitCode, IO, IOApp}
 import sttp.tapir.server.netty.cats.@if(addMetrics){{NettyCatsServer, NettyCatsServerOptions}}else{NettyCatsServer}
 
 @if(addMetrics){import java.net.InetSocketAddress}
-import scala.io.StdIn
 
 object Main extends IOApp:
-  val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+  val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
   override def run(args: List[String]): IO[ExitCode] =
     @if(addMetrics){
@@ -29,10 +28,8 @@ object Main extends IOApp:
             .host("localhost")
             .addEndpoints(Endpoints.all)
             .start()
-          _ <- IO.blocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.port}. }Press ENTER key to exit.")
-            StdIn.readLine()
-          }
+          _ <- IO.println(s"@if(addDocumentation){Go to http://localhost:${bind.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.port}. }Press ENTER key to exit.")
+          _ <- IO.readLine
           _ <- bind.stop()
         yield bind
       }

--- a/backend/src/main/twirl/MainIOVertx.scala.txt
+++ b/backend/src/main/twirl/MainIOVertx.scala.txt
@@ -8,13 +8,10 @@ import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.cats.@if(addMetrics){{VertxCatsServerInterpreter, VertxCatsServerOptions}}else{VertxCatsServerInterpreter}
 import sttp.tapir.server.vertx.cats.VertxCatsServerInterpreter._
 
-import scala.io.StdIn
-
-
 object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     val vertx = Vertx.vertx()
     val server = vertx.createHttpServer()
@@ -40,10 +37,8 @@ object Main extends IOApp {
               })
             server.requestHandler(router).listen(port)
           }.flatMap(_.asF[IO])
-          _ <- IO.blocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${bind.actualPort()}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.actualPort()}. }Press ENTER key to exit.")
-            StdIn.readLine()
-          }
+          _ <- IO.println(s"@if(addDocumentation){Go to http://localhost:${bind.actualPort()}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.actualPort()}. }Press ENTER key to exit.")
+          _ <- IO.readLine
           _ <- IO.delay(server.close).flatMap(_.asF[IO].void)
         } yield bind
       }

--- a/backend/src/main/twirl/MainIOVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainIOVertxScala3.scala.txt
@@ -8,13 +8,10 @@ import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.cats.@if(addMetrics){{VertxCatsServerInterpreter, VertxCatsServerOptions}}else{VertxCatsServerInterpreter}
 import sttp.tapir.server.vertx.cats.VertxCatsServerInterpreter._
 
-import scala.io.StdIn
-
-
 object Main extends IOApp:
 
   override def run(args: List[String]): IO[ExitCode] =
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     val vertx = Vertx.vertx()
     val server = vertx.createHttpServer()
@@ -40,10 +37,8 @@ object Main extends IOApp:
               })
             server.requestHandler(router).listen(port)
           }.flatMap(_.asF[IO])
-          _ <- IO.blocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${bind.actualPort()}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.actualPort()}. }Press ENTER key to exit.")
-            StdIn.readLine()
-          }
+          _ <- IO.println(s"@if(addDocumentation){Go to http://localhost:${bind.actualPort()}/docs to open SwaggerUI. }else{Server started at http://localhost:${bind.actualPort()}. }Press ENTER key to exit.")
+          _ <- IO.readLine
           _ <- IO.delay(server.close).flatMap(_.asF[IO].void)
         } yield bind
       }

--- a/backend/src/main/twirl/MainZIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4s.scala.txt
@@ -6,8 +6,7 @@ import org.http4s.server.Router@if(addMetrics){
 import sttp.tapir.server.http4s.Http4sServerOptions}
 import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 import zio.interop.catz._
-import zio.{Scope, Task, ZIO, ZIOAppArgs, ZIOAppDefault}
-import scala.io.StdIn
+import zio.{Scope, Task, ZIO, ZIOAppArgs, ZIOAppDefault, Console}
 
 object Main extends ZIOAppDefault {
 
@@ -22,7 +21,7 @@ object Main extends ZIOAppDefault {
     val routes = ZHttp4sServerInterpreter().from(Endpoints.all).toRoutes
     }
 
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     ZIO.executor.flatMap{ executor =>
       BlazeServerBuilder[Task]
@@ -31,11 +30,11 @@ object Main extends ZIOAppDefault {
         .withHttpApp(Router("/" -> (routes)).orNotFound)
         .resource
         .use { server =>
-          ZIO.succeedBlocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
-            StdIn.readLine()
-          }
-        }.unit
+          for {
+            _ <- Console.printLine(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
+            _ <- Console.readLine
+          } yield ()
+        }
     }
   }
 }

--- a/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
@@ -6,8 +6,7 @@ import org.http4s.server.Router@if(addMetrics){
 import sttp.tapir.server.http4s.Http4sServerOptions}
 import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 import zio.interop.catz.*
-import zio.{Scope, Task, ZIO, ZIOAppArgs, ZIOAppDefault}
-import scala.io.StdIn
+import zio.{Scope, Task, ZIO, ZIOAppArgs, ZIOAppDefault, Console}
 
 object Main extends ZIOAppDefault:
 
@@ -22,7 +21,7 @@ object Main extends ZIOAppDefault:
     val routes = ZHttp4sServerInterpreter().from(Endpoints.all).toRoutes
     }
 
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     ZIO.executor.flatMap{ executor =>
       BlazeServerBuilder[Task]
@@ -31,10 +30,10 @@ object Main extends ZIOAppDefault:
         .withHttpApp(Router("/" -> routes).orNotFound)
         .resource
         .use { server =>
-          ZIO.succeedBlocking {
-            println(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
-            StdIn.readLine()
-          }
-        }.unit
+          for {
+            _ <- Console.printLine(s"@if(addDocumentation){Go to http://localhost:${server.address.getPort}/docs to open SwaggerUI. }else{Server started at http://localhost:${server.address.getPort}. }Press ENTER key to exit.")
+            _ <- Console.readLine
+          } yield ()
+        }
     }
 

--- a/backend/src/main/twirl/MainZIOVertx.scala.txt
+++ b/backend/src/main/twirl/MainZIOVertx.scala.txt
@@ -13,7 +13,7 @@ object Main extends ZIOAppDefault {
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
 
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
     val vertx = Vertx.vertx()
     val server = vertx.createHttpServer()
     val router = Router.router(vertx)

--- a/backend/src/main/twirl/MainZIOVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOVertxScala3.scala.txt
@@ -13,7 +13,7 @@ object Main extends ZIOAppDefault:
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
 
-    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+    val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
     val vertx = Vertx.vertx()
     val server = vertx.createHttpServer()
     val router = Router.router(vertx)


### PR DESCRIPTION
Refactor templates:
-  Use built-in methods for reading from and printing to the console in ZIO and cats. 
- Change the name of the env variable for setting the port number to HTTP_PORT.