### PR TITLE
Refactor CorrelationId

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/Main.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/Main.scala
@@ -2,11 +2,13 @@ package com.softwaremill.adopttapir
 
 import cats.effect.{ExitCode, IO, IOApp, Resource}
 import com.softwaremill.adopttapir.config.Config
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 
 object Main extends IOApp:
 
   override def run(args: List[String]): IO[ExitCode] =
     val server = for
+      given CorrelationId <- Resource.eval(CorrelationId.init)
       config <- Resource.eval(Config.read)
       dependencies <- Dependencies.wire(config)
       _ <- dependencies.api.resource

--- a/backend/src/main/scala/com/softwaremill/adopttapir/config/Config.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/config/Config.scala
@@ -2,6 +2,7 @@ package com.softwaremill.adopttapir.config
 
 import cats.effect.IO
 import com.softwaremill.adopttapir.http.HttpConfig
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.logging.FLogging
 import com.softwaremill.adopttapir.starter.files.StorageConfig
 import com.softwaremill.adopttapir.version.BuildInfo
@@ -14,7 +15,7 @@ import scala.collection.immutable.TreeMap
 final case class Config(api: HttpConfig, storageConfig: StorageConfig) derives ConfigReader
 
 object Config extends FLogging:
-  private def log(config: Config): IO[Unit] =
+  private def log(config: Config)(using CorrelationId): IO[Unit] =
     val baseInfo = s"""
                       |Adopt-tapir configuration:
                       |-----------------------
@@ -31,7 +32,7 @@ object Config extends FLogging:
 
     logger.info(info)
 
-  def read: IO[Config] = for
+  def read(using CorrelationId): IO[Config] = for
     config <- IO(ConfigSource.default.loadOrThrow[Config])
     _ <- log(config)
   yield config

--- a/backend/src/main/scala/com/softwaremill/adopttapir/http/Http.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/http/Http.scala
@@ -3,11 +3,12 @@ package com.softwaremill.adopttapir.http
 import cats.effect.IO
 import cats.syntax.all.*
 import com.softwaremill.adopttapir.*
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.infrastructure.Json.*
 import com.softwaremill.adopttapir.logging.FLogging
 import com.softwaremill.adopttapir.util.Constants
 import com.softwaremill.tagging.*
-import io.circe.{Printer, Encoder, Decoder}
+import io.circe.{Decoder, Encoder, Printer}
 import sttp.model.StatusCode
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.json.circe.TapirJsonCirce
@@ -16,7 +17,7 @@ import sttp.tapir.generic.Configuration as TapirConfiguration
 import io.circe.generic.semiauto.*
 
 /** Helper class for defining HTTP endpoints. Import the members of this class when defining an HTTP API using tapir. */
-class Http() extends Tapir, TapirJsonCirce, FLogging:
+class Http(using CorrelationId) extends Tapir, TapirJsonCirce, FLogging:
 
   given TapirConfiguration =
     TapirConfiguration.default
@@ -47,7 +48,7 @@ class Http() extends Tapir, TapirJsonCirce, FLogging:
     def toOut: IO[Either[(StatusCode, Error_OUT), T]] =
       io.map(t => t.asRight[(StatusCode, Error_OUT)]).recoverWith { case f: Fail =>
         val (statusCode, message) = failToResponseData(f)
-        logger.warn[IO](s"Request fail: ${message.error}").map(_ => (statusCode, message).asLeft[T])
+        logger.warn(s"Request fail: ${message.error}").map(_ => (statusCode, message).asLeft[T])
       }
 
   override def jsonPrinter: Printer = noNullsPrinter

--- a/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.adopttapir.http
 
 import cats.effect.{IO, Resource}
-import com.softwaremill.adopttapir.infrastructure.CorrelationIdInterceptor
+import com.softwaremill.adopttapir.infrastructure.{CorrelationIdInterceptor, CorrelationId}
 import com.softwaremill.adopttapir.logging.FLogging
 import com.softwaremill.adopttapir.util.ServerEndpoints
 import org.http4s.HttpRoutes
@@ -32,23 +32,24 @@ class HttpApi(
     adminEndpoints: ServerEndpoints,
     prometheusMetrics: PrometheusMetrics[IO],
     config: HttpConfig
-) extends FLogging:
+)(using c: CorrelationId)
+    extends FLogging:
 
   private val apiContextPath = List("api", "v1")
 
   private val serverOptions: Http4sServerOptions[IO] = Http4sServerOptions
     .customiseInterceptors[IO]
-    .prependInterceptor(CorrelationIdInterceptor)
+    .prependInterceptor(CorrelationIdInterceptor.create)
     // all errors are formatted as json, and there are no other additional http4s routes
     .defaultHandlers(msg => ValuedEndpointOutput(http.jsonErrorOutOutput, Error_OUT(msg)), notFoundWhenRejected = true)
     .serverLog {
       // using a context-aware logger for http logging
       Http4sServerOptions
         .defaultServerLog[IO]
-        .doLogWhenHandled((msg, e) => e.fold(logger.debug[IO](msg))(logger.debug(msg, _)))
-        .doLogAllDecodeFailures((msg, e) => e.fold(logger.debug[IO](msg))(logger.debug(msg, _)))
-        .doLogExceptions((msg, e) => logger.error[IO](msg, e))
-        .doLogWhenReceived(msg => logger.debug[IO](msg))
+        .doLogWhenHandled((msg, e) => e.fold(logger.debug(msg))(logger.debug(msg, _)))
+        .doLogAllDecodeFailures((msg, e) => e.fold(logger.debug(msg))(logger.debug(msg, _)))
+        .doLogExceptions((msg, e) => logger.error(msg, e))
+        .doLogWhenReceived(msg => logger.debug(msg))
     }
     .corsInterceptor(CORSInterceptor.default[IO])
     .metricsInterceptor(prometheusMetrics.metricsInterceptor())

--- a/backend/src/main/scala/com/softwaremill/adopttapir/logging/FLogging.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/logging/FLogging.scala
@@ -1,27 +1,30 @@
 package com.softwaremill.adopttapir.logging
 
-import com.softwaremill.adopttapir.infrastructure.CorrelationIdSource
+import cats.effect.IO
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.typesafe.scalalogging.Logger
 import org.slf4j.{LoggerFactory, MDC}
-
+import cats.syntax.all.*
 trait FLogging:
   private val delegate = Logger(LoggerFactory.getLogger(getClass.getName))
   protected def logger: FLogger = new FLogger(delegate)
 
 class FLogger private[logging] (delegate: Logger):
   private val MDCKey = "cid"
-  private def withMDC[F[_]: CorrelationIdSource, T](t: => T): F[T] =
-    summon[CorrelationIdSource[F]].map { cid =>
-      cid.foreach(x => MDC.put(MDCKey, x))
-      try t
-      finally MDC.remove(MDCKey)
+  private def withMDC[T](t: => T)(using cid: CorrelationId): IO[T] =
+    val iot = IO(t)
+
+    cid.get.flatMap { cid =>
+      cid
+        .fold(iot)(x => IO(MDC.put(MDCKey, x)) *> iot)
+        .guarantee(IO(MDC.remove(MDCKey)))
     }
 
-  def debug[F[_]: CorrelationIdSource](message: String): F[Unit] = withMDC(delegate.debug(message))
-  def debug[F[_]: CorrelationIdSource](message: String, cause: Throwable): F[Unit] = withMDC(delegate.debug(message, cause))
-  def info[F[_]: CorrelationIdSource](message: String): F[Unit] = withMDC(delegate.info(message))
-  def info[F[_]: CorrelationIdSource](message: String, cause: Throwable): F[Unit] = withMDC(delegate.info(message, cause))
-  def warn[F[_]: CorrelationIdSource](message: String): F[Unit] = withMDC(delegate.warn(message))
-  def warn[F[_]: CorrelationIdSource](message: String, cause: Throwable): F[Unit] = withMDC(delegate.warn(message, cause))
-  def error[F[_]: CorrelationIdSource](message: String): F[Unit] = withMDC(delegate.error(message))
-  def error[F[_]: CorrelationIdSource](message: String, cause: Throwable): F[Unit] = withMDC(delegate.error(message, cause))
+  def debug(message: String)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.debug(message))
+  def debug(message: String, cause: Throwable)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.debug(message, cause))
+  def info(message: String)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.info(message))
+  def info(message: String, cause: Throwable)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.info(message, cause))
+  def warn(message: String)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.warn(message))
+  def warn(message: String, cause: Throwable)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.warn(message, cause))
+  def error(message: String)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.error(message))
+  def error(message: String, cause: Throwable)(using cid: CorrelationId): IO[Unit] = withMDC(delegate.error(message, cause))

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
@@ -7,10 +7,12 @@ import com.softwaremill.adopttapir.starter.files.FilesManager
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
 import com.softwaremill.adopttapir.template.ProjectGenerator
 import cats.syntax.all.*
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 
 import java.io.File
 
-class StarterService(generatedFilesFormatter: GeneratedFilesFormatter, filesManager: FilesManager)(using Metrics) extends FLogging:
+class StarterService(generatedFilesFormatter: GeneratedFilesFormatter, filesManager: FilesManager)(using Metrics, CorrelationId)
+    extends FLogging:
 
   def generateZipFile(starterDetails: StarterDetails): IO[File] =
     for {

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
@@ -2,6 +2,7 @@ package com.softwaremill.adopttapir.starter
 
 import cats.effect.{ExitCode, IO, IOApp, Resource}
 import com.softwaremill.adopttapir.config.Config
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.metrics.Metrics
 import com.softwaremill.adopttapir.starter.files.FilesManager
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
@@ -11,6 +12,7 @@ import com.softwaremill.adopttapir.template.ProjectGenerator
 object FileOperation extends IOApp:
 
   val createService: Resource[IO, StarterService] = for {
+    given CorrelationId <- Resource.eval(CorrelationId.init)
     cfg <- Resource.eval(Config.read.map(_.storageConfig.copy(deleteTempFolder = false)))
     fm = FilesManager(cfg)
     given Metrics <- Resource.eval(Metrics.init())

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/content/ContentServiceTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/content/ContentServiceTest.scala
@@ -8,14 +8,17 @@ import com.softwaremill.adopttapir.starter.{Setup, StarterDetails}
 import com.softwaremill.adopttapir.template.ProjectGenerator
 import com.softwaremill.adopttapir.test.BaseTest
 import cats.effect.unsafe.implicits.global
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.metrics.Metrics
 class ContentServiceTest extends BaseTest:
 
   object ContentServiceTest:
     val service: Resource[IO, ContentService] =
       val sc = StorageConfig(deleteTempFolder = true, tempPrefix = "generatedService")
-      val metrics = Metrics.noop
-      GeneratedFilesFormatter.create(FilesManager(sc)).map(ContentService(_)(using metrics))
+      for
+        given CorrelationId <- Resource.eval(CorrelationId.init)
+        service <- GeneratedFilesFormatter.create(FilesManager(sc)).map(ContentService(_)(using Metrics.noop))
+      yield service
 
   import ContentServiceTest._
 

--- a/backend/src/test/scala/com/softwaremill/adopttapir/test/TestDependencies.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/test/TestDependencies.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.softwaremill.adopttapir.config.Config
 import com.softwaremill.adopttapir.Dependencies
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.SttpBackend
@@ -13,6 +14,8 @@ import sttp.tapir.server.stub.TapirStubInterpreter
 
 trait TestDependencies extends BeforeAndAfterAll:
   self: Suite with BaseTest =>
+  given CorrelationId = CorrelationId.init.unsafeRunSync()
+
   var dependencies: Dependencies = _
   var releaseDependencies: IO[Unit] = _
   val TestConfig: Config = Config.read.unsafeRunSync()


### PR DESCRIPTION
`CorrelationId` no longer is created using `unsafeRunSync`. It is now initialized in `Main` and passed down as an implicit parameter.