### PR TITLE
Put zipped files in a root directory

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
@@ -26,7 +26,7 @@ class StarterService(generatedFilesFormatter: GeneratedFilesFormatter, filesMana
             tempDir <- tempDirectory
             _ <- logger.debug("Created temp dir: " + tempDir)
             _ <- filesManager.createFiles(tempDir, formattedGeneratedFiles)
-            zippedFile <- filesManager.zipDirectory(tempDir)
+            zippedFile <- filesManager.zipDirectory(tempDir, zipRootDirName = starterDetails.projectName)
             _ <- Metrics.increaseZipGenerationMetricCounter(starterDetails)
           yield zippedFile
         }(release = tempDirectory => filesManager.deleteFilesAsStatedInConfig(tempDirectory))

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/files/FilesManager.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/files/FilesManager.scala
@@ -26,10 +26,10 @@ class FilesManager(config: StorageConfig):
       file.toJava
     }
 
-  def zipDirectory(directoryFile: File): IO[File] =
+  def zipDirectory(directoryFile: File, zipRootDirName: String): IO[File] =
     IO.blocking {
       val destination = BFile.newTemporaryFile(prefix = directoryFile.getName + "_", suffix = ".zip")
-      ZipArchiver().create(destination.path, directoryFile.toPath)
+      ZipArchiver().create(destination.path, directoryFile.toPath, zipRootDirName)
       destination.toJava
     }
 

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -147,7 +147,7 @@ case class GeneratedServiceUnderTest(serviceFactory: ServiceFactory, details: St
       tempDir <- createTempDirectory()
     yield (zipFile, tempDir))
       .use { case (zipFile, tempDir) =>
-        unzipFile(zipFile, tempDir, logger) >> spawnService(tempDir).use(service =>
+        unzipFile(zipFile, tempDir, logger) >> spawnService(tempDir, details.projectName).use(service =>
           getPortFromService(service, logger).flatMap(port => runTests(port, tests, logger))
         )
       }
@@ -169,8 +169,8 @@ case class GeneratedServiceUnderTest(serviceFactory: ServiceFactory, details: St
   private def unzipFile(zipFile: BFile, tempDir: BFile, logger: RunLogger): IO[Unit] =
     IO.blocking(zipFile.unzipTo(tempDir)) >> logger.log("* zip file was unzipped")
 
-  private def spawnService(tempDir: BFile): Resource[IO, GeneratedService] =
-    Resource.make(serviceFactory.create(details.builder, tempDir))(_.close())
+  private def spawnService(tempDir: BFile, projectName: String): Resource[IO, GeneratedService] =
+    Resource.make(serviceFactory.create(details.builder, tempDir / projectName))(_.close())
 
   private def getPortFromService(service: GeneratedService, logger: RunLogger): IO[Integer] =
     for

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
@@ -14,7 +14,11 @@ import com.softwaremill.adopttapir.test.{BaseTest, TestDependencies}
 import fs2.io.file.Files
 import io.circe.jawn
 import org.scalatest.Assertion
+import better.files.{DisposeableExtensions, File}
 import sttp.client3.{HttpError, Response, SttpClientException}
+import java.nio.file.attribute.PosixFilePermissions
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel
+import org.apache.commons.compress.archivers.zip.ZipFile
 
 class StarterApiTest extends BaseTest with TestDependencies {
 
@@ -40,6 +44,21 @@ class StarterApiTest extends BaseTest with TestDependencies {
         "README.md",
         ".gitignore"
       )
+    }
+  }
+
+  "/starter.zip" should "return a zip containing sbtx with permissions 755" in {
+    // given
+    val req = validSbtRequest
+
+    // when
+    val response: Response[fs2.Stream[IO, Byte]] = requests.requestZip(req)
+
+    // then
+    response.code.code shouldBe 200
+
+    checkStreamZip(response.body) { zippedFile =>
+      checkZipEntry(zippedFile)(_.getEntry(s"${req.projectName}/sbtx").getUnixMode shouldBe 493)
     }
   }
 
@@ -80,14 +99,17 @@ class StarterApiTest extends BaseTest with TestDependencies {
         val paths = unpackedDir.listRecursively.toList
           .collect {
             case f: File
-                if f.path.toString.endsWith(".scala") && !f.path
-                  .endsWith("build.scala") && !f.path.endsWith("build.test.scala") && f.isRegularFile =>
+                if f.path.toString.endsWith("README.md") ||
+                  f.path.toString.endsWith(".scala") && !f.path
+                    .endsWith("build.scala") && !f.path.endsWith("build.test.scala") && f.isRegularFile =>
               unpackedDir.relativize(f)
           }
+        val root = req.projectName
         paths.map(_.toString) should contain theSameElementsAs List(
-          s"$mainPath/$groupIdRelativePath/Main.scala",
-          s"src/main/scala/$groupIdRelativePath/Endpoints.scala",
-          s"src/test/scala/$groupIdRelativePath/EndpointsSpec.scala"
+          s"$root/README.md",
+          s"$root/$mainPath/$groupIdRelativePath/Main.scala",
+          s"$root/src/main/scala/$groupIdRelativePath/Endpoints.scala",
+          s"$root/src/test/scala/$groupIdRelativePath/EndpointsSpec.scala"
         )
       }
     }
@@ -124,6 +146,18 @@ class StarterApiTest extends BaseTest with TestDependencies {
     )
   }
 
+  def checkStreamZip[A](fileStream: fs2.Stream[IO, Byte])(assertionOnZipFn: File => A): Unit = {
+    tempZipFile().use { case tempZipFile =>
+      for
+        _ <- fileStream
+          .through(Files[IO].writeAll(fs2.io.file.Path(tempZipFile.toJava.getPath)))
+          .compile
+          .drain
+        _ <- IO.blocking(assertionOnZipFn(tempZipFile))
+      yield ()
+    }.unwrap
+  }
+
   def checkStreamZipContent(fileStream: fs2.Stream[IO, Byte])(assertionOnUnpackedDirFn: File => Assertion): Unit = {
     (for
       tempZipFile <- tempZipFile()
@@ -146,6 +180,15 @@ class StarterApiTest extends BaseTest with TestDependencies {
 
   private def tempDir(): Resource[IO, File] = Resource
     .make(IO.blocking(better.files.File.newTemporaryDirectory("starterApiTest")))(f => IO.blocking(f.delete()))
+}
+
+private def checkZipEntry[A](zippedFile: File)(applyFn: ZipFile => A) = {
+  for
+    channel <- new SeekableInMemoryByteChannel(zippedFile.byteArray).autoClosed
+    zipFile <- new ZipFile(channel).autoClosed
+  do {
+    applyFn(zipFile)
+  }
 }
 
 object StarterApiTest {

--- a/backend/src/test/scala/com/softwaremill/adopttapir/util/ZipArchiverTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/util/ZipArchiverTest.scala
@@ -26,10 +26,10 @@ class ZipArchiverTest extends BaseTest with BeforeAndAfter:
     val zippedFile: File = better.files.File.newTemporaryFile("ZipArchiverTest", ".zip").deleteOnExit()
 
     // when
-    ZipArchiver(Map(file.name -> ZipArchiver.chmod755)).create(zippedFile.path, dirToZip.path)
+    ZipArchiver(Map(file.name -> ZipArchiver.chmod755)).create(zippedFile.path, dirToZip.path, "root-dir")
 
     // then
-    checkZipEntry(file.name, zippedFile)(_.getEntry(file.name).getUnixMode shouldBe ZipArchiver.chmod755)
+    checkZipEntry(zippedFile)(_.getEntry(s"root-dir/${file.name}").getUnixMode shouldBe ZipArchiver.chmod755)
   }
 
   it should "not set unix file permission if it is NOT specified on Map" in {
@@ -39,13 +39,13 @@ class ZipArchiverTest extends BaseTest with BeforeAndAfter:
     val zippedFile: File = better.files.File.newTemporaryFile("ZipArchiverTest", ".zip").deleteOnExit()
 
     // when
-    ZipArchiver(Map("otherFile" -> ZipArchiver.chmod755)).create(zippedFile.path, dirToZip.path)
+    ZipArchiver(Map("otherFile" -> ZipArchiver.chmod755)).create(zippedFile.path, dirToZip.path, "root-dir")
 
     // then
-    checkZipEntry(file.name, zippedFile)(_.getEntry(file.name).getUnixMode shouldBe 0)
+    checkZipEntry(zippedFile)(_.getEntry(s"root-dir/${file.name}").getUnixMode shouldBe 0)
   }
 
-  private def checkZipEntry[A](filename: String, zippedFile: File)(applyFn: ZipFile => A) = {
+  private def checkZipEntry[A](zippedFile: File)(applyFn: ZipFile => A) = {
     for
       channel <- new SeekableInMemoryByteChannel(zippedFile.byteArray).autoClosed
       zipFile <- new ZipFile(channel).autoClosed


### PR DESCRIPTION
Conventionally there's a parent directory in a zip, so that `unzip file.zip` won't mess up the directory where it's called. In this case, the project name will be used as the directory name.