### PR TITLE
feat: add Apache Pekko to server implementations

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterModel.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterModel.scala
@@ -31,6 +31,7 @@ enum ServerImplementation(val name: String):
   case Http4s extends ServerImplementation("Http4s")
   case ZIOHttp extends ServerImplementation("ZIO Http")
   case VertX extends ServerImplementation("Vert.X")
+  case Pekko extends ServerImplementation("Pekko")
 
 enum ServerEffect(val name: String):
   case FutureEffect extends ServerEffect("Future")

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
@@ -1,8 +1,8 @@
 package com.softwaremill.adopttapir.starter.api
 
-import com.softwaremill.adopttapir.starter.{Builder, JsonImplementation, ScalaVersion, ServerEffect, ServerImplementation}
-import io.circe.{Decoder, Encoder}
+import com.softwaremill.adopttapir.starter.*
 import io.circe.generic.semiauto.*
+import io.circe.{Decoder, Encoder}
 import org.latestbit.circe.adt.codec.*
 import sttp.tapir.Schema
 
@@ -34,7 +34,8 @@ enum EffectRequest(val toModel: ServerEffect, val legalServerImplementations: Se
         ServerEffect.FutureEffect,
         legalServerImplementations = Set(
           ServerImplementation.Netty,
-          ServerImplementation.VertX
+          ServerImplementation.VertX,
+          ServerImplementation.Pekko
         )
       )
   case IOEffect
@@ -62,6 +63,7 @@ enum ServerImplementationRequest(val toModel: ServerImplementation) derives Json
   case Http4s extends ServerImplementationRequest(ServerImplementation.Http4s)
   case ZIOHttp extends ServerImplementationRequest(ServerImplementation.ZIOHttp)
   case VertX extends ServerImplementationRequest(ServerImplementation.VertX)
+  case Pekko extends ServerImplementationRequest(ServerImplementation.Pekko)
 
 enum JsonImplementationRequest(val toModel: JsonImplementation) derives JsonTaggedAdt.PureEncoder, JsonTaggedAdt.PureDecoder, Schema:
   case No extends JsonImplementationRequest(JsonImplementation.WithoutJson)

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequestValidator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequestValidator.scala
@@ -1,14 +1,13 @@
 package com.softwaremill.adopttapir.starter.api
 
-import cats.data.ValidatedNec
+import cats.data.{Validated, ValidatedNec}
 import cats.syntax.all.*
 import com.softwaremill.adopttapir.Fail.*
 import com.softwaremill.adopttapir.starter.StarterDetails
-import com.softwaremill.adopttapir.starter.api.EffectRequest.{FutureEffect, IOEffect, ZIOEffect}
+import com.softwaremill.adopttapir.starter.api.EffectRequest.ZIOEffect
 import com.softwaremill.adopttapir.starter.api.JsonImplementationRequest.ZIOJson
 import com.softwaremill.adopttapir.starter.api.RequestValidation.{GroupIdShouldFollowJavaPackageConvention, ProjectNameShouldMatchRegex}
-import com.softwaremill.adopttapir.starter.api.ServerImplementationRequest.{Http4s, Netty, ZIOHttp, VertX}
-import cats.data.Validated
+import com.softwaremill.adopttapir.starter.api.ServerImplementationRequest.{Http4s, Netty, Pekko, VertX, ZIOHttp}
 
 sealed trait RequestValidation:
   def errMessage: String
@@ -88,7 +87,7 @@ sealed trait FormValidator:
       addMetrics: Boolean
   ): ValidatedNec[RequestValidation, Boolean] =
     (effect, serverImplementation, addMetrics) match {
-      case t @ (_, Http4s | ZIOHttp | Netty | VertX, _) => t._3.validNec
+      case t @ (_, Http4s | ZIOHttp | Netty | VertX | Pekko, _) => t._3.validNec
     }
 
   private def validateEffectWithJson(

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
@@ -1,12 +1,10 @@
 package com.softwaremill.adopttapir.template
 
+import com.softwaremill.adopttapir.starter.*
 import com.softwaremill.adopttapir.starter.ServerEffect.{FutureEffect, IOEffect, ZIOEffect}
-import com.softwaremill.adopttapir.starter.ServerImplementation.{Http4s, Netty, ZIOHttp, VertX}
-import com.softwaremill.adopttapir.starter.{JsonImplementation, ServerEffect, StarterDetails}
-import Dependency.{JavaDependency, ScalaDependency, ScalaTestDependency, constantTapirVersion}
+import com.softwaremill.adopttapir.starter.ServerImplementation.{Http4s, Netty, Pekko, VertX, ZIOHttp}
+import com.softwaremill.adopttapir.template.Dependency.{JavaDependency, ScalaDependency, ScalaTestDependency, constantTapirVersion}
 import com.softwaremill.adopttapir.version.TemplateDependencyInfo
-import com.softwaremill.adopttapir.starter.ServerEffectAndImplementation
-import com.softwaremill.adopttapir.starter.ServerImplementation
 
 abstract class BuildView:
   def getAllDependencies(starterDetails: StarterDetails): List[Dependency] =
@@ -60,6 +58,7 @@ abstract class BuildView:
       case ServerImplementation.ZIOHttp => logbackClassic ++ zioLoggingDependencies
       case ServerImplementation.Http4s  => logbackClassic
       case ServerImplementation.VertX   => logbackClassic
+      case ServerImplementation.Pekko   => logbackClassic
 
   private def getJsonDependencies(starterDetails: StarterDetails): List[ScalaDependency] =
     starterDetails.jsonImplementation match {
@@ -109,6 +108,7 @@ abstract class BuildView:
     starterDetails match {
       case ServerEffectAndImplementation(FutureEffect, Netty) => HttpDependencies.netty()
       case ServerEffectAndImplementation(FutureEffect, VertX) => HttpDependencies.vertX()
+      case ServerEffectAndImplementation(FutureEffect, Pekko) => HttpDependencies.pekko()
       case ServerEffectAndImplementation(IOEffect, Http4s)    => HttpDependencies.http4s()
       case ServerEffectAndImplementation(IOEffect, Netty)     => HttpDependencies.ioNetty()
       case ServerEffectAndImplementation(IOEffect, VertX)     => HttpDependencies.ioVerteX()
@@ -157,6 +157,10 @@ abstract class BuildView:
 
     def ZIONetty(): List[ScalaDependency] = List(
       ScalaDependency("com.softwaremill.sttp.tapir", "tapir-netty-server-zio", getTapirVersion())
+    )
+
+    def pekko(): List[ScalaDependency] = List(
+      ScalaDependency("com.softwaremill.sttp.tapir", "tapir-pekko-http-server", getTapirVersion())
     )
 
 end BuildView

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/MainView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/MainView.scala
@@ -14,6 +14,8 @@ object MainView:
             txt.MainFutureNetty(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, FutureEffect, VertX, addDocumentation, addMetrics, _, _, _) =>
             txt.MainFutureVertx(groupId, addDocumentation, addMetrics).toString()
+          case StarterDetails(_, groupId, FutureEffect, Pekko, addDocumentation, addMetrics, _, _, _) =>
+            txt.MainFuturePekko(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, IOEffect, Http4s, addDocumentation, addMetrics, _, _, _) =>
             txt.MainIOHttp4s(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, IOEffect, Netty, addDocumentation, addMetrics, _, _, _) =>
@@ -36,6 +38,8 @@ object MainView:
             txt.MainFutureNettyScala3(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, FutureEffect, VertX, addDocumentation, addMetrics, _, _, _) =>
             txt.MainFutureVertxScala3(groupId, addDocumentation, addMetrics).toString()
+          case StarterDetails(_, groupId, FutureEffect, Pekko, addDocumentation, addMetrics, _, _, _) =>
+            txt.MainFuturePekkoScala3(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, IOEffect, Http4s, addDocumentation, addMetrics, _, _, _) =>
             txt.MainIOHttp4sScala3(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, IOEffect, Netty, addDocumentation, addMetrics, _, _, _) =>

--- a/backend/src/main/twirl/MainFuturePekko.scala.txt
+++ b/backend/src/main/twirl/MainFuturePekko.scala.txt
@@ -1,0 +1,41 @@
+@(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
+package @groupId
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import sttp.tapir.server.pekkohttp.@if(addMetrics){{PekkoHttpServerInterpreter, PekkoHttpServerOptions}}else{PekkoHttpServerInterpreter}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.io.StdIn
+
+object Main {
+
+  def main(args: Array[String]): Unit = {
+    implicit val actorSystem: ActorSystem = ActorSystem()
+
+    @if(addMetrics) {
+    val serverOptions: PekkoHttpServerOptions =
+      PekkoHttpServerOptions.customiseInterceptors
+        .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+        .options
+
+    val route = PekkoHttpServerInterpreter(serverOptions).toRoute(Endpoints.all)
+    } else {
+    val route = PekkoHttpServerInterpreter().toRoute(Endpoints.all)
+    }
+
+    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+
+    val bindingFuture = Http()
+      .newServerAt("localhost", port)
+      .bindFlow(route)
+      .map { binding =>
+         println(s"@if(addDocumentation){Go to http://localhost:${binding.localAddress.getPort}/docs to open SwaggerUI.}else{Server started at http://localhost:${binding.localAddress.getPort}.} Press ENTER key to exit.")
+         binding
+      }
+
+    StdIn.readLine()
+
+    bindingFuture.flatMap(_.unbind()).onComplete(_ => actorSystem.terminate())
+  }
+}

--- a/backend/src/main/twirl/MainFuturePekkoScala3.scala.txt
+++ b/backend/src/main/twirl/MainFuturePekkoScala3.scala.txt
@@ -1,0 +1,37 @@
+@(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
+package @groupId
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import sttp.tapir.server.pekkohttp.@if(addMetrics){{PekkoHttpServerInterpreter, PekkoHttpServerOptions}}else{PekkoHttpServerInterpreter}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.io.StdIn
+
+@@main def run(): Unit =
+  implicit val actorSystem: ActorSystem = ActorSystem()
+
+  @if(addMetrics) {
+  val serverOptions: PekkoHttpServerOptions =
+    PekkoHttpServerOptions.customiseInterceptors
+      .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+      .options
+
+  val route = PekkoHttpServerInterpreter(serverOptions).toRoute(Endpoints.all)
+  } else {
+  val route = PekkoHttpServerInterpreter().toRoute(Endpoints.all)
+  }
+
+  val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+
+  val bindingFuture = Http()
+    .newServerAt("localhost", port)
+    .bindFlow(route)
+    .map { binding =>
+       println(s"@if(addDocumentation){Go to http://localhost:${binding.localAddress.getPort}/docs to open SwaggerUI.}else{Server started at http://localhost:${binding.localAddress.getPort}.} Press ENTER key to exit.")
+       binding
+    }
+
+  StdIn.readLine()
+
+  bindingFuture.flatMap(_.unbind()).onComplete(_ => actorSystem.terminate())

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/FormValidatorTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/FormValidatorTest.scala
@@ -52,11 +52,11 @@ class FormValidatorTest extends BaseTest:
 
   it should "raise a problem when effect will not match implementation" in {
     FormValidator.validate(randomStarterRequest(FutureEffect, ZIOHttp)).left.value.msg should
-      include("Picked FutureEffect with ZIOHttp - Future effect will work only with: Netty, Vert.X")
+      include("Picked FutureEffect with ZIOHttp - Future effect will work only with: Netty, Vert.X, Pekko")
     FormValidator.validate(randomStarterRequest(FutureEffect, Http4s)).left.value.msg should
-      include("Picked FutureEffect with Http4s - Future effect will work only with: Netty, Vert.X")
+      include("Picked FutureEffect with Http4s - Future effect will work only with: Netty, Vert.X, Pekko")
     FormValidator.validate(randomStarterRequest(IOEffect, ZIOHttp)).left.value.msg should
-      include("Picked IOEffect with ZIOHttp - IO effect will work only with: Netty, Vert.X, Http4s")
+      be("Picked IOEffect with ZIOHttp - IO effect will work only with: Netty, Vert.X, Http4s")
   }
 
   it should "not raise a problem with Effect and Implementation" in {

--- a/ui/src/api/starter.ts
+++ b/ui/src/api/starter.ts
@@ -12,6 +12,7 @@ export enum EffectImplementation {
   Http4s = 'Http4s',
   ZIOHttp = 'ZIOHttp',
   VertX = 'VertX',
+  Pekko = 'Pekko',
 }
 
 export enum JSONImplementation {

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
@@ -58,6 +58,10 @@ export const EFFECT_IMPLEMENTATIONS_OPTIONS: FormSelectOption<EffectImplementati
     label: 'Vert.X',
     value: EffectImplementation.VertX,
   },
+  {
+    label: 'Pekko HTTP',
+    value: EffectImplementation.Pekko,
+  },
 ];
 
 export const ENDPOINTS_OPTIONS: FormRadioOption<boolean>[] = [

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.helpers.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.helpers.ts
@@ -8,7 +8,7 @@ import type { FormRadioOption } from '../FormRadioGroup';
  */
 
 const effectTypeImplementationMap: Record<EffectType, EffectImplementation[]> = {
-  [EffectType.Future]: [EffectImplementation.Netty, EffectImplementation.VertX],
+  [EffectType.Future]: [EffectImplementation.Netty, EffectImplementation.VertX, EffectImplementation.Pekko],
   [EffectType.IO]: [EffectImplementation.Http4s, EffectImplementation.Netty, EffectImplementation.VertX],
   [EffectType.ZIO]: [
     EffectImplementation.Netty,

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.consts.test.ts
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.consts.test.ts
@@ -137,6 +137,7 @@ describe('configuration consts', () => {
         [EffectType.Future, ScalaVersion.Scala2, EffectImplementation.Netty, true],
         [EffectType.Future, ScalaVersion.Scala2, EffectImplementation.Http4s, false],
         [EffectType.Future, ScalaVersion.Scala2, EffectImplementation.ZIOHttp, false],
+        [EffectType.Future, ScalaVersion.Scala2, EffectImplementation.Pekko, true],
 
         [EffectType.IO, ScalaVersion.Scala2, EffectImplementation.Netty, true],
         [EffectType.IO, ScalaVersion.Scala2, EffectImplementation.Http4s, true],
@@ -150,6 +151,7 @@ describe('configuration consts', () => {
         [EffectType.Future, ScalaVersion.Scala3, EffectImplementation.Netty, true],
         [EffectType.Future, ScalaVersion.Scala3, EffectImplementation.Http4s, false],
         [EffectType.Future, ScalaVersion.Scala3, EffectImplementation.ZIOHttp, false],
+        [EffectType.Future, ScalaVersion.Scala3, EffectImplementation.Pekko, true],
 
         [EffectType.IO, ScalaVersion.Scala3, EffectImplementation.Netty, true],
         [EffectType.IO, ScalaVersion.Scala3, EffectImplementation.Http4s, true],

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.helpers.test.ts
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.helpers.test.ts
@@ -1,4 +1,4 @@
-import { EffectType, EffectImplementation, ScalaVersion, JSONImplementation } from 'api/starter';
+import { EffectImplementation, EffectType, JSONImplementation, ScalaVersion } from 'api/starter';
 import {
   getAvailableEffectImplementations,
   getEffectImplementationOptions,
@@ -10,7 +10,11 @@ import type { FormRadioOption } from '../../FormRadioGroup';
 describe('configuration form helpers', () => {
   describe('.getAvailableEffectImplementations()', () => {
     const cases: [EffectType, ScalaVersion, EffectImplementation[]][] = [
-      [EffectType.Future, ScalaVersion.Scala2, [EffectImplementation.Netty, EffectImplementation.VertX]],
+      [
+        EffectType.Future,
+        ScalaVersion.Scala2,
+        [EffectImplementation.Netty, EffectImplementation.VertX, EffectImplementation.Pekko],
+      ],
       [
         EffectType.IO,
         ScalaVersion.Scala2,
@@ -27,7 +31,11 @@ describe('configuration form helpers', () => {
         ],
       ],
 
-      [EffectType.Future, ScalaVersion.Scala3, [EffectImplementation.Netty, EffectImplementation.VertX]],
+      [
+        EffectType.Future,
+        ScalaVersion.Scala3,
+        [EffectImplementation.Netty, EffectImplementation.VertX, EffectImplementation.Pekko],
+      ],
       [
         EffectType.IO,
         ScalaVersion.Scala3,
@@ -66,6 +74,10 @@ describe('configuration form helpers', () => {
           {
             label: 'Vert.X',
             value: EffectImplementation.VertX,
+          },
+          {
+            label: 'Pekko HTTP',
+            value: EffectImplementation.Pekko,
           },
         ],
       ],
@@ -121,6 +133,10 @@ describe('configuration form helpers', () => {
           {
             label: 'Vert.X',
             value: EffectImplementation.VertX,
+          },
+          {
+            label: 'Pekko HTTP',
+            value: EffectImplementation.Pekko,
           },
         ],
       ],


### PR DESCRIPTION
The following change add Apache Pekko to server implementations for the `Future` effect for both `Scala 2` and `Scala 3` destinations.

Here is the UI screenshot:
![image](https://github.com/softwaremill/adopt-tapir/assets/3641082/faa61960-a4d9-49f9-b06b-ad6eda1906e1)

Note that integration is being confirmed through the integration, UI and manual tests.

Closes #446 .