### PR TITLE
fix: `preview` metrics are not emitted

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/content/ContentService.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/content/ContentService.scala
@@ -21,5 +21,5 @@ final case class ContentService(generatedFilesFormatter: GeneratedFilesFormatter
         DirectoryMerger(projectName, paths, content)
       }))
       projectAsTree <- IO(projectAsDirTrees.reduce(DirectoryMerger.apply))
-      _ <- IO(Metrics.increasePreviewOperationMetricCounter(starterDetails))
+      _ <- Metrics.increasePreviewOperationMetricCounter(starterDetails)
     yield projectAsTree

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/MetricsEmittedTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/MetricsEmittedTest.scala
@@ -1,0 +1,54 @@
+package com.softwaremill.adopttapir.starter
+
+import cats.effect.{IO, Resource}
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
+import com.softwaremill.adopttapir.metrics.Metrics
+import com.softwaremill.adopttapir.starter.content.ContentService
+import com.softwaremill.adopttapir.starter.files.{FilesManager, StorageConfig}
+import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
+import com.softwaremill.adopttapir.test.BaseTest
+import org.scalatest.Assertion
+
+class MetricsEmittedTest extends BaseTest:
+  import MetricsEmittedTest.*
+  import cats.effect.unsafe.implicits.global
+
+  it should "emit 'preview' metric when preview service is called" in withMetricsService { metrics =>
+    val contentService: Resource[IO, ContentService] =
+      val sc = StorageConfig(deleteTempFolder = true, tempPrefix = "generatedService")
+      for
+        given CorrelationId <- Resource.eval(CorrelationId.init)
+        service <- GeneratedFilesFormatter.create(FilesManager(sc)).map(ContentService(_)(using metrics))
+      yield service
+
+    contentService.use(_.generateContentTree(Setup.validConfigurations.head)).unsafeRunSync()
+
+    metrics.called should have size 1
+    metrics.called.head should equal("preview")
+  }
+
+  it should "emit 'generate' metric when starter service is called" in withMetricsService { metrics =>
+    val starterService: Resource[IO, StarterService] =
+      val fm = new FilesManager(StorageConfig(deleteTempFolder = true, tempPrefix = "generatedService"))
+      for
+        given CorrelationId <- Resource.eval(CorrelationId.init)
+        service <- GeneratedFilesFormatter.create(fm).map(StarterService(_, fm)(using metrics))
+      yield service
+
+    starterService.use(_.generateZipFile(Setup.validConfigurations.head)).unsafeRunSync()
+
+    metrics.called should have size 1
+    metrics.called.head should equal("generate")
+  }
+
+object MetricsEmittedTest:
+  def withMetricsService(testCode: (TestMetrics) => Assertion): Assertion =
+    testCode(new TestMetrics)
+
+  class TestMetrics extends Metrics:
+    var called: List[String] = List.empty
+
+    override def increaseMetricCounter(details: StarterDetails, operation: String): IO[Unit] =
+      IO.blocking { called = called :+ operation }
+
+end MetricsEmittedTest

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/content/ContentServiceTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/content/ContentServiceTest.scala
@@ -1,15 +1,13 @@
 package com.softwaremill.adopttapir.starter.content
 
-import cats.effect.{IO, Resource}
-import com.softwaremill.adopttapir.starter.files.StorageConfig
-import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
-import com.softwaremill.adopttapir.starter.files.FilesManager
-import com.softwaremill.adopttapir.starter.{Setup, StarterDetails}
-import com.softwaremill.adopttapir.template.ProjectGenerator
-import com.softwaremill.adopttapir.test.BaseTest
 import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Resource}
 import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.metrics.Metrics
+import com.softwaremill.adopttapir.starter.Setup
+import com.softwaremill.adopttapir.starter.files.{FilesManager, StorageConfig}
+import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
+import com.softwaremill.adopttapir.test.BaseTest
 class ContentServiceTest extends BaseTest:
 
   object ContentServiceTest:
@@ -20,13 +18,10 @@ class ContentServiceTest extends BaseTest:
         service <- GeneratedFilesFormatter.create(FilesManager(sc)).map(ContentService(_)(using Metrics.noop))
       yield service
 
-  import ContentServiceTest._
+  import ContentServiceTest.*
 
-  it should "generate project tree for every valid configuration" in {
-    allStarterDetails().foreach(sd => {
-      service.use(_.generateContentTree(sd))
-      // The content tree generation failure results in the exception being thrown and as a result a test failure
-    })
+  it should "generate project tree for a valid configuration" in {
+    // The content tree generation failure results in the exception being thrown and as a result a test failure
+    // note that there is no point in re-testing all configurations generation as that gets validated in StartetServiceITTest
+    service.use(_.generateContentTree(Setup.validConfigurations.head)).unsafeRunSync()
   }
-
-  private def allStarterDetails(): Seq[StarterDetails] = Setup.validConfigurations


### PR DESCRIPTION
The following PR contains two fixes:
1. it fixes the `ContentServiceTest` as it was not calling the content service but was just creating service resource - note that the test gets reduced to a single scenario as so that verification is not doubled
2. it fixes the missing `preview` metrics issue - in addition it add the unit tests that verifies if the both content and generate services are emitting metrics

Closes #474 