### PR TITLE
Fix compilation warnings

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/Dependencies.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/Dependencies.scala
@@ -4,13 +4,13 @@ import cats.data.{NonEmptyList, Reader, ReaderT}
 import cats.effect.{IO, Resource}
 import cats.syntax.all.*
 import com.softwaremill.adopttapir.config.Config
-import com.softwaremill.adopttapir.http.{Http, HttpApi, HttpConfig}
+import com.softwaremill.adopttapir.http.{Http, HttpApi}
 import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.metrics.{Metrics, VersionApi}
 import com.softwaremill.adopttapir.starter.StarterService
-import com.softwaremill.adopttapir.starter.files.FilesManager
 import com.softwaremill.adopttapir.starter.api.StarterApi
 import com.softwaremill.adopttapir.starter.content.ContentService
+import com.softwaremill.adopttapir.starter.files.FilesManager
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
 import sttp.tapir.server.metrics.prometheus.PrometheusMetrics
 

--- a/backend/src/main/scala/com/softwaremill/adopttapir/http/Http.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/http/Http.scala
@@ -7,14 +7,11 @@ import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.infrastructure.Json.*
 import com.softwaremill.adopttapir.logging.FLogging
 import com.softwaremill.adopttapir.util.Constants
-import com.softwaremill.tagging.*
 import io.circe.{Decoder, Encoder, Printer}
 import sttp.model.StatusCode
-import sttp.tapir.Codec.PlainCodec
-import sttp.tapir.json.circe.TapirJsonCirce
-import sttp.tapir.{Codec, Endpoint, EndpointOutput, PublicEndpoint, Schema, SchemaType, Tapir}
 import sttp.tapir.generic.Configuration as TapirConfiguration
-import io.circe.generic.semiauto.*
+import sttp.tapir.json.circe.TapirJsonCirce
+import sttp.tapir.{EndpointOutput, PublicEndpoint, Schema, SchemaType, Tapir}
 
 /** Helper class for defining HTTP endpoints. Import the members of this class when defining an HTTP API using tapir. */
 class Http(using CorrelationId) extends Tapir, TapirJsonCirce, FLogging:

--- a/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
@@ -9,12 +9,12 @@ import org.http4s.HttpRoutes
 import org.http4s.ember.server.EmberServerBuilder
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.*
+import sttp.tapir.files.{FilesOptions, staticResourcesGetServerEndpoint}
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.http4s.{Http4sServerInterpreter, Http4sServerOptions}
 import sttp.tapir.server.interceptor.cors.CORSInterceptor
 import sttp.tapir.server.metrics.prometheus.PrometheusMetrics
 import sttp.tapir.server.model.ValuedEndpointOutput
-import sttp.tapir.static.ResourcesOptions
 import sttp.tapir.swagger.SwaggerUIOptions
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
@@ -74,10 +74,10 @@ class HttpApi(
     // directory on the classpath; otherwise, returning index.html; this is needed to support paths in the frontend
     // apps (e.g. /login) the frontend app will handle displaying appropriate error messages
     val webappEndpoints = List(
-      resourcesGetServerEndpoint[IO](emptyInput: EndpointInput[Unit])(
+      staticResourcesGetServerEndpoint[IO](emptyInput: EndpointInput[Unit])(
         classOf[HttpApi].getClassLoader,
         "webapp",
-        ResourcesOptions.default.defaultResource(List("index.html"))
+        FilesOptions.default.defaultFile(List("index.html"))
       )
     )
     apiEndpoints.toList ++ webappEndpoints

--- a/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
@@ -18,8 +18,6 @@ import sttp.tapir.static.ResourcesOptions
 import sttp.tapir.swagger.SwaggerUIOptions
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
-import scala.util.chaining.*
-
 /** Interprets the endpoint descriptions (defined using tapir) as http4s routes, adding CORS, metrics, api docs support.
   *
   * The following endpoints are exposed on `config.port`

--- a/backend/src/main/scala/com/softwaremill/adopttapir/infrastructure/Json.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/infrastructure/Json.scala
@@ -1,6 +1,5 @@
 package com.softwaremill.adopttapir.infrastructure
 
-import com.softwaremill.adopttapir.util.Constants
 import com.softwaremill.tagging.@@
 import io.circe.{Decoder, Encoder, Printer}
 

--- a/backend/src/main/scala/com/softwaremill/adopttapir/metrics/VersionApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/metrics/VersionApi.scala
@@ -4,10 +4,9 @@ import cats.effect.IO
 import com.softwaremill.adopttapir.http.Http
 import com.softwaremill.adopttapir.infrastructure.Json.*
 import com.softwaremill.adopttapir.version.BuildInfo
-import sttp.tapir.server.ServerEndpoint
-import io.circe.{Encoder, Decoder}
-import io.circe.generic.semiauto.*
+import io.circe.{Decoder, Encoder}
 import sttp.tapir.Schema
+import sttp.tapir.server.ServerEndpoint
 
 /** Defines an endpoint which exposes the current application version information.
   */

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterService.scala
@@ -1,13 +1,12 @@
 package com.softwaremill.adopttapir.starter
 
 import cats.effect.IO
+import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.logging.FLogging
 import com.softwaremill.adopttapir.metrics.Metrics
 import com.softwaremill.adopttapir.starter.files.FilesManager
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
 import com.softwaremill.adopttapir.template.ProjectGenerator
-import cats.syntax.all.*
-import com.softwaremill.adopttapir.infrastructure.CorrelationId
 
 import java.io.File
 

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
@@ -5,7 +5,6 @@ import cats.effect.IO
 import cats.syntax.all.*
 import com.softwaremill.adopttapir.Fail
 import com.softwaremill.adopttapir.http.Http
-import com.softwaremill.adopttapir.infrastructure.Json._
 import com.softwaremill.adopttapir.starter.*
 import com.softwaremill.adopttapir.starter.content.{ContentService, Node}
 import com.softwaremill.adopttapir.util.ServerEndpoints

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/content/ContentModel.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/content/ContentModel.scala
@@ -1,13 +1,9 @@
 package com.softwaremill.adopttapir.starter.content
 
 import cats.syntax.all.*
-import io.circe.{Encoder, Decoder}
 import io.circe.*
-import io.circe.parser.*
 import io.circe.syntax.*
-import io.circe.generic.semiauto.*
 import sttp.tapir.Schema
-import io.circe.*
 
 sealed trait Node:
   def name: String

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/formatting/GeneratedFilesFormatter.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/formatting/GeneratedFilesFormatter.scala
@@ -1,11 +1,10 @@
 package com.softwaremill.adopttapir.starter.formatting
 
-import cats.effect.{IO, Resource}
 import cats.effect.std.Dispatcher
+import cats.effect.{IO, Resource}
 import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.logging.FLogging
 import com.softwaremill.adopttapir.starter.files.FilesManager
-import com.softwaremill.adopttapir.starter.files.StorageConfig
 import com.softwaremill.adopttapir.template.{CommonObjectTemplate, GeneratedFile}
 import org.scalafmt.interfaces.{Scalafmt, ScalafmtReporter}
 

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
@@ -2,7 +2,7 @@ package com.softwaremill.adopttapir.template
 
 import better.files.Resource
 import com.softwaremill.adopttapir.starter.ServerEffect.ZIOEffect
-import com.softwaremill.adopttapir.starter.{Builder, ScalaVersion, StarterDetails, ServerImplementation}
+import com.softwaremill.adopttapir.starter.{Builder, ScalaVersion, StarterDetails}
 import com.softwaremill.adopttapir.template.scala.{EndpointsSpecView, EndpointsView, Import, MainView}
 import com.softwaremill.adopttapir.version.TemplateDependencyInfo
 
@@ -31,7 +31,7 @@ abstract class ProjectTemplate:
       getEndpoints(starterDetails),
       getEndpointsSpec(starterDetails),
       scalafmtConf(starterDetails.scalaVersion)
-    ) ++ getLogback(starterDetails)
+    ) ++ getLogback()
   }
 
   private def getMain(starterDetails: StarterDetails): GeneratedFile = {
@@ -111,7 +111,7 @@ abstract class ProjectTemplate:
     )
   }
 
-  private def getLogback(starterDetails: StarterDetails): List[GeneratedFile] =
+  private def getLogback(): List[GeneratedFile] =
     List(
       GeneratedFile("src/main/resources/logback.xml", txt.logback().toString)
     )

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/FileOperation.scala
@@ -6,7 +6,6 @@ import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.metrics.Metrics
 import com.softwaremill.adopttapir.starter.files.FilesManager
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
-import com.softwaremill.adopttapir.template.ProjectGenerator
 
 @deprecated("Only for development purpose")
 object FileOperation extends IOApp:

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -11,7 +11,6 @@ import com.softwaremill.adopttapir.metrics.Metrics
 import com.softwaremill.adopttapir.starter.api.*
 import com.softwaremill.adopttapir.starter.files.{FilesManager, StorageConfig}
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
-import com.softwaremill.adopttapir.template.ProjectGenerator
 import com.softwaremill.adopttapir.test.ServiceTimeouts.waitForPortTimeout
 import com.softwaremill.adopttapir.test.ShowHelpers.*
 import com.softwaremill.adopttapir.test.{BaseTest, GeneratedService, ServiceFactory}
@@ -21,7 +20,6 @@ import sttp.client3.{HttpURLConnectionBackend, Identity, SttpBackend, UriContext
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Properties
-import scala.reflect.ClassTag
 
 object Setup:
   type TestFunction = Integer => IO[Unit]

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -197,5 +197,5 @@ object ZipGenerator:
     yield service
 
 case class RunLogger(log: mutable.StringBuilder = new mutable.StringBuilder()):
-  def log(l: String): IO[Unit] = IO(log.append(System.lineSeparator()).append(l))
+  def log(l: String): IO[Unit] = IO(log.append(System.lineSeparator()).append(l)).void
   override def toString: String = log.toString()

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/api/StarterApiTest.scala
@@ -1,6 +1,6 @@
 package com.softwaremill.adopttapir.starter.api
 
-import better.files.File
+import better.files.{DisposeableExtensions, File}
 import cats.effect.{IO, Resource}
 import com.softwaremill.adopttapir.http.Error_OUT
 import com.softwaremill.adopttapir.infrastructure.Json.*
@@ -13,12 +13,10 @@ import com.softwaremill.adopttapir.test.RichIO.unwrap
 import com.softwaremill.adopttapir.test.{BaseTest, TestDependencies}
 import fs2.io.file.Files
 import io.circe.jawn
-import org.scalatest.Assertion
-import better.files.{DisposeableExtensions, File}
-import sttp.client3.{HttpError, Response, SttpClientException}
-import java.nio.file.attribute.PosixFilePermissions
-import org.apache.commons.compress.utils.SeekableInMemoryByteChannel
 import org.apache.commons.compress.archivers.zip.ZipFile
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel
+import org.scalatest.Assertion
+import sttp.client3.{HttpError, Response, SttpClientException}
 
 class StarterApiTest extends BaseTest with TestDependencies {
 

--- a/backend/src/test/scala/com/softwaremill/adopttapir/test/Requests.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/test/Requests.scala
@@ -3,11 +3,9 @@ package com.softwaremill.adopttapir.test
 import cats.effect.IO
 import com.softwaremill.adopttapir.starter.api.StarterRequest
 import com.softwaremill.adopttapir.test.RichIO.unwrap
-import com.softwaremill.adopttapir.infrastructure.Json.*
 import io.circe.syntax.EncoderOps
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.{Response, SttpBackend, UriContext, asStreamUnsafe, basicRequest}
-import org.latestbit.circe.adt.codec.*
 
 class Requests(backend: SttpBackend[IO, Any with Fs2Streams[IO]]):
 


### PR DESCRIPTION
The following warnings are fixed:
* about unused imports and parameters
* about discarded non-Unit value of type
* about `apirStaticContentEndpoints is deprecated`

_Note_
Warnings about `unused import` from Twirl generated sources e.g.
```
[warn] /Users/jcentkowski/workspace/sml/adopt-tapir/backend/src/main/twirl/Endpoints.scala.txt:1:1: unused import
[warn] @(
[warn] ^
```
were not fixed.
The problem is that regardless of what is written in [scala.lang.org](https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html) neither `src` nor `origin` nor `site` filters are available as of `scalac` version `3.3.1` - here is the output of `help` command
```
$ scalac -Wconf:help
Configure compiler warnings.
Syntax: -Wconf:<filters>:<action>,<filters>:<action>,...
multiple <filters> are combined with &, i.e., <filter>&...&<filter>

<filter>
  - Any message: any

  - Message categories: cat=deprecation, cat=feature, cat=unchecked

  - Message content: msg=regex
    The regex need only match some part of the message, not all of it.

  - Message id: id=E129
    The message id is printed with the warning.

  - Message name: name=PureExpressionInStatementPosition
    The message name is printed with the warning in verbose warning mode.

In verbose warning mode the compiler prints matching filters for warnings.
Verbose mode can be enabled globally using `-Wconf:any:verbose`, or locally
using the @nowarn annotation (example: `@nowarn("v") def test = try 1`).

<action>
  - error / e
  - warning / w
  - verbose / v (emit warning, show additional help for writing `-Wconf` filters)
  - info / i    (infos are not counted as warnings and not affected by `-Werror`)
  - silent / s

The default configuration is empty.

User-defined configurations are added to the left. The leftmost rule matching
a warning message defines the action.

Examples:
  - change every warning into an error: -Wconf:any:error
  - silence deprecations: -Wconf:cat=deprecation:s

Note: on the command-line you might need to quote configurations containing `*` or `&`
to prevent the shell from expanding patterns.
```

The only way to silence `unused import` warning was to add
```scala
scalacOptions += "-Wconf:msg=unused import:s",
```
to `build.sbt` but that would also silence warnings in every `*.scala` files hence it would be too much 😢 

Closes #478 