### PR TITLE
chore: upgrade GH Actions to the latest available major versions

### DIFF
--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Check-out repository
         id: repo-checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17 with sbt cache
         uses: actions/setup-java@v3
@@ -50,13 +50,13 @@ jobs:
     steps:
       - name: Check-out repository
         id: repo-checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache scala-cli
-        uses: coursier/cache-action@v6.3
+        uses: coursier/cache-action@v6
 
       - name: Set up scala-cli
-        uses: VirtusLab/scala-cli-setup@v1.0.1
+        uses: VirtusLab/scala-cli-setup@v1
         with:
           jvm: temurin:17
 
@@ -83,7 +83,7 @@ jobs:
     steps:
       - name: Check-out repository
         id: repo-checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17 with sbt cache
         uses: actions/setup-java@v3
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: Check-out repository
         id: repo-checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         id: jdk-setup
@@ -125,7 +125,7 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
So that the newest actions could be used (see the corresponding issue for details).
The following actions were upgraded:
* actions/checkout@v4
* coursier/cache-action@v6
* VirtusLab/scala-cli-setup@v1
* docker/login-action@v3

Closes #480 