### PR TITLE
Support netty-sync

### DIFF
--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -24,11 +24,11 @@ jobs:
         id: repo-checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17 with sbt cache
+      - name: Set up JDK 21 with sbt cache
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'sbt'
 
       - name: Check formatting
@@ -61,7 +61,7 @@ jobs:
       - name: Set up scala-cli
         uses: VirtusLab/scala-cli-setup@v1
         with:
-          jvm: temurin:17
+          jvm: temurin:21
 
       - name: Cache SBT
         id: cache-sbt
@@ -88,11 +88,11 @@ jobs:
         id: repo-checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17 with sbt cache
+      - name: Set up JDK 21 with sbt cache
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'sbt'
 
       - name: Build docker image locally
@@ -109,12 +109,12 @@ jobs:
         id: repo-checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         id: jdk-setup
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'sbt'
 
       - name: Cache SBT

--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -24,11 +24,11 @@ jobs:
         id: repo-checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21 with sbt cache
+      - name: Set up JDK 17 with sbt cache
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 17
           cache: 'sbt'
 
       - name: Check formatting
@@ -63,7 +63,7 @@ jobs:
       - name: Set up scala-cli
         uses: VirtusLab/scala-cli-setup@v1
         with:
-          jvm: temurin:21
+          jvm: ${{ matrix.effect == 'Sync' && 'temurin:21' || 'temurin:17' }}
 
       - name: Cache SBT
         id: cache-sbt

--- a/.github/workflows/adopt-tapir-ci.yml
+++ b/.github/workflows/adopt-tapir-ci.yml
@@ -46,10 +46,12 @@ jobs:
       matrix:
         scala: [ "Scala2", "Scala3" ]
         json: [ "No", "Circe", "UPickle", "Jsoniter", "ZIOJson", "Pickler" ]
+        effect: [ "Sync", "FutureEffect", "IOEffect", "ZIOEffect" ]
         exclude:
           - scala: "Scala2"
             json: "Pickler"
-
+          - scala: "Scala2"
+            effect: "Sync"
     steps:
       - name: Check-out repository
         id: repo-checkout
@@ -73,8 +75,8 @@ jobs:
             ~/.coursier
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
-      - name: Run integration tests for ${{ matrix.scala }} with ${{ matrix.json }} JSON support
-        run: SCALA=${{ matrix.scala }} JSON=${{ matrix.json }} IT_TESTS_THREADS_NO=1 sbt 'ItTest / test'
+      - name: Run integration tests for ${{ matrix.effect }}, ${{ matrix.scala }} with ${{ matrix.json }} JSON support
+        run: SCALA=${{ matrix.scala }} JSON=${{ matrix.json }} EFFECT=${{ matrix.effect }} IT_TESTS_THREADS_NO=1 sbt 'ItTest / test'
 
   verify_docker_image_build:
     if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterModel.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/StarterModel.scala
@@ -37,6 +37,7 @@ enum ServerEffect(val name: String):
   case FutureEffect extends ServerEffect("Future")
   case IOEffect extends ServerEffect("IO")
   case ZIOEffect extends ServerEffect("ZIO")
+  case Sync extends ServerEffect("Sync")
 
 enum JsonImplementation:
   case WithoutJson, Circe, UPickle, Jsoniter, ZIOJson, Pickler

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
@@ -57,6 +57,13 @@ enum EffectRequest(val toModel: ServerEffect, val legalServerImplementations: Se
           ServerImplementation.ZIOHttp
         )
       )
+  case Sync
+      extends EffectRequest(
+        ServerEffect.Sync,
+        legalServerImplementations = Set(
+          ServerImplementation.Netty
+        )
+      )
 
 enum ServerImplementationRequest(val toModel: ServerImplementation) derives JsonTaggedAdt.PureEncoder, JsonTaggedAdt.PureDecoder, Schema:
   case Netty extends ServerImplementationRequest(ServerImplementation.Netty)

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequestValidator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequestValidator.scala
@@ -47,7 +47,7 @@ sealed trait FormValidator:
     (
       validateProjectName(r.projectName),
       validateGroupId(r.groupId),
-      validateEffectWithImplementation(r.effect, r.implementation),
+      validateEffectWithImplementation(r.effect, r.implementation, r.scalaVersion),
       validateMetrics(r.effect, r.implementation, r.addMetrics),
       validateJson(r.effect, r.scalaVersion, r.json)
     ).mapN { case (projectName, groupId, (effect, serverImplementation), addMetrics, json) =>
@@ -77,10 +77,13 @@ sealed trait FormValidator:
 
   private def validateEffectWithImplementation(
       effect: EffectRequest,
-      serverImplementation: ServerImplementationRequest
+      serverImplementation: ServerImplementationRequest,
+      scalaVersionRequest: ScalaVersionRequest
   ): ValidatedNec[RequestValidation, (EffectRequest, ServerImplementationRequest)] =
     Validated.condNec(
-      effect.legalServerImplementations.contains(serverImplementation.toModel),
+      effect.legalServerImplementations.contains(
+        serverImplementation.toModel
+      ) && !(effect == EffectRequest.Sync && scalaVersionRequest == ScalaVersionRequest.Scala2),
       (effect, serverImplementation),
       RequestValidation.EffectWithIllegalServerImplementation(effect, serverImplementation)
     )

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
@@ -137,7 +137,7 @@ abstract class BuildView:
 
     def syncNetty(): List[ScalaDependency] =
       List(
-        ScalaDependency("com.softwaremill.sttp.tapir", "tapir-netty-sync", getTapirVersion())
+        ScalaDependency("com.softwaremill.sttp.tapir", "tapir-netty-server-sync", getTapirVersion())
       )
 
     def http4s(): List[ScalaDependency] = List(

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.adopttapir.template
 
 import com.softwaremill.adopttapir.starter.*
-import com.softwaremill.adopttapir.starter.ServerEffect.{FutureEffect, IOEffect, ZIOEffect}
+import com.softwaremill.adopttapir.starter.ServerEffect.{FutureEffect, IOEffect, Sync, ZIOEffect}
 import com.softwaremill.adopttapir.starter.ServerImplementation.{Http4s, Netty, Pekko, VertX, ZIOHttp}
 import com.softwaremill.adopttapir.template.Dependency.{JavaDependency, ScalaDependency, ScalaTestDependency, constantTapirVersion}
 import com.softwaremill.adopttapir.version.TemplateDependencyInfo
@@ -115,6 +115,7 @@ abstract class BuildView:
       case ServerEffectAndImplementation(FutureEffect, Pekko) => HttpDependencies.pekko()
       case ServerEffectAndImplementation(IOEffect, Http4s)    => HttpDependencies.http4s()
       case ServerEffectAndImplementation(IOEffect, Netty)     => HttpDependencies.ioNetty()
+      case ServerEffectAndImplementation(Sync, Netty)         => HttpDependencies.syncNetty()
       case ServerEffectAndImplementation(IOEffect, VertX)     => HttpDependencies.ioVerteX()
       case ServerEffectAndImplementation(ZIOEffect, Http4s)   => HttpDependencies.http4sZIO()
       case ServerEffectAndImplementation(ZIOEffect, ZIOHttp)  => HttpDependencies.ZIOHttp()
@@ -132,6 +133,11 @@ abstract class BuildView:
       List(
         ScalaDependency("com.softwaremill.sttp.tapir", "tapir-cats-effect", getTapirVersion()),
         ScalaDependency("com.softwaremill.sttp.tapir", "tapir-netty-server-cats", getTapirVersion())
+      )
+
+    def syncNetty(): List[ScalaDependency] =
+      List(
+        ScalaDependency("com.softwaremill.sttp.tapir", "tapir-netty-sync", getTapirVersion())
       )
 
     def http4s(): List[ScalaDependency] = List(

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
@@ -1,7 +1,7 @@
 package com.softwaremill.adopttapir.template
 
 import better.files.Resource
-import com.softwaremill.adopttapir.starter.ServerEffect.ZIOEffect
+import com.softwaremill.adopttapir.starter.ServerEffect.{Sync, ZIOEffect}
 import com.softwaremill.adopttapir.starter.{Builder, ScalaVersion, StarterDetails}
 import com.softwaremill.adopttapir.template.scala.{EndpointsSpecView, EndpointsView, Import, MainView}
 import com.softwaremill.adopttapir.version.TemplateDependencyInfo
@@ -86,6 +86,16 @@ abstract class ProjectTemplate:
       if starterDetails.serverEffect == ZIOEffect then {
         txt
           .EndpointsSpecZIO(
+            starterDetails,
+            toSortedList(helloServerStub.imports ++ booksServerStub.imports),
+            helloServerStub.body,
+            booksServerStub.body,
+            starterDetails.scalaVersion,
+            starterDetails.jsonImplementation
+          )
+      } else if starterDetails.serverEffect == Sync then {
+        txt
+          .EndpointsSpecSync(
             starterDetails,
             toSortedList(helloServerStub.imports ++ booksServerStub.imports),
             helloServerStub.body,

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
@@ -43,6 +43,7 @@ object EndpointsSpecView:
         case ServerEffect.FutureEffect => "SttpBackendStub.asynchronousFuture"
         case ServerEffect.IOEffect     => "SttpBackendStub(new CatsMonadError[IO]())"
         case ServerEffect.ZIOEffect    => "SttpBackendStub(new RIOMonadError[Any])"
+        case ServerEffect.Sync         => "SttpBackendStub.synchronous"
       }
 
       val body =

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsSpecView.scala
@@ -2,6 +2,7 @@ package com.softwaremill.adopttapir.template.scala
 
 import com.softwaremill.adopttapir.starter.{JsonImplementation, ScalaVersion, ServerEffect, StarterDetails}
 import com.softwaremill.adopttapir.template.scala.EndpointsView.Constants.{booksListingServerEndpoint, helloServerEndpoint}
+import org.http4s.headers.Server
 
 object EndpointsSpecView:
 
@@ -64,7 +65,8 @@ object EndpointsSpecView:
           Set(
             Import("sttp.tapir.ztapir.RIOMonadError")
           )
-
+        case ServerEffect.Sync =>
+          Set.empty
       }
 
       Code(body, imports)
@@ -101,4 +103,6 @@ object EndpointsSpecView:
           Code(prepareBody("IO[T]", "t.unsafeRunSync()"), Set(Import("cats.effect.unsafe.implicits.global")))
         case ServerEffect.ZIOEffect =>
           Code(prepareBody("ZIO[Any, Throwable, T]", "zio.Runtime.default.unsafeRun(t)"), Set(Import("zio.ZIO")))
+        case ServerEffect.Sync =>
+          throw new UnsupportedOperationException("Should not unwrap Sync effect")
       }

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
@@ -31,11 +31,12 @@ object EndpointsView:
     )
 
     val sync: Code = Code(
-      s"""${INDENT}val $helloServerEndpoint: ServerEndpoint[Any, Any] = $helloEndpoint.serverLogicSuccess(user =>
+      s"""${INDENT}val $helloServerEndpoint: ServerEndpoint[Any, Id] = $helloEndpoint.serverLogicSuccess(user =>
          |  s"Hello $${user.name}"
          |)""".stripMargin,
       Set(
-        Import("sttp.tapir.server.ServerEndpoint")
+        Import("sttp.tapir.server.ServerEndpoint"),
+        Import("sttp.tapir.server.netty.sync.Id")
       )
     )
 
@@ -174,7 +175,7 @@ object EndpointsView:
     private def prepareBookListingServerLogic(starterDetails: StarterDetails): Code =
       val (serverKind, pureEffectFn) = starterDetails.serverEffect match {
         case ServerEffect.FutureEffect => ("ServerEndpoint[Any, Future]", "Future.successful")
-        case ServerEffect.FutureEffect => ("ServerEndpoint[Any, Any]", "")
+        case ServerEffect.Sync         => ("ServerEndpoint[Any, Id]", "")
         case ServerEffect.IOEffect     => ("ServerEndpoint[Any, IO]", "IO.pure")
         case ServerEffect.ZIOEffect    => ("ZServerEndpoint[Any, Any]", "ZIO.succeed")
       }
@@ -189,7 +190,7 @@ object EndpointsView:
   def getApiEndpoints(starterDetails: StarterDetails): Code =
     val serverKind = starterDetails.serverEffect match {
       case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
-      case ServerEffect.Sync         => "List[ServerEndpoint[Any, Any]]"
+      case ServerEffect.Sync         => "List[ServerEndpoint[Any, Id]]"
       case ServerEffect.IOEffect     => "List[ServerEndpoint[Any, IO]]"
       case ServerEffect.ZIOEffect    => "List[ZServerEndpoint[Any, Any]]"
     }
@@ -243,7 +244,7 @@ object EndpointsView:
   private def serverEffectToEffectAndEndpoint(serverEffect: ServerEffect): (String, String) =
     serverEffect match {
       case ServerEffect.FutureEffect => ("Future", "ServerEndpoint[Any, Future]")
-      case ServerEffect.Sync         => ("Sync", "ServerEndpoint[Any, Any]")
+      case ServerEffect.Sync         => ("Id", "ServerEndpoint[Any, Id]")
       case ServerEffect.IOEffect     => ("IO", "ServerEndpoint[Any, IO]")
       case ServerEffect.ZIOEffect    => ("Task", "ZServerEndpoint[Any, Any]")
     }
@@ -257,7 +258,7 @@ object EndpointsView:
   def getAllEndpoints(starterDetails: StarterDetails): Code =
     val serverKind = starterDetails.serverEffect match {
       case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
-      case ServerEffect.Sync         => "List[ServerEndpoint[Any, Any]]"
+      case ServerEffect.Sync         => "List[ServerEndpoint[Any, Id]]"
       case ServerEffect.IOEffect     => "List[ServerEndpoint[Any, IO]]"
       case ServerEffect.ZIOEffect    => "List[ZServerEndpoint[Any, Any]]"
     }

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
@@ -11,6 +11,7 @@ object EndpointsView:
       case ServerEffect.FutureEffect => HelloServerEndpoint.future
       case ServerEffect.IOEffect     => HelloServerEndpoint.io
       case ServerEffect.ZIOEffect    => HelloServerEndpoint.zio
+      case ServerEffect.Sync         => HelloServerEndpoint.sync
     }
 
     helloServerCode.prependBody(INDENT)
@@ -25,6 +26,15 @@ object EndpointsView:
       bodyTemplate("ServerEndpoint[Any, Future]", "Future.successful"),
       Set(
         Import("scala.concurrent.Future"),
+        Import("sttp.tapir.server.ServerEndpoint")
+      )
+    )
+
+    val sync: Code = Code(
+      s"""${INDENT}val $helloServerEndpoint: ServerEndpoint[Any, Any] = $helloEndpoint.serverLogicSuccess(user =>
+         |  s"Hello $${user.name}"
+         |)""".stripMargin,
+      Set(
         Import("sttp.tapir.server.ServerEndpoint")
       )
     )
@@ -164,6 +174,7 @@ object EndpointsView:
     private def prepareBookListingServerLogic(starterDetails: StarterDetails): Code =
       val (serverKind, pureEffectFn) = starterDetails.serverEffect match {
         case ServerEffect.FutureEffect => ("ServerEndpoint[Any, Future]", "Future.successful")
+        case ServerEffect.FutureEffect => ("ServerEndpoint[Any, Any]", "")
         case ServerEffect.IOEffect     => ("ServerEndpoint[Any, IO]", "IO.pure")
         case ServerEffect.ZIOEffect    => ("ZServerEndpoint[Any, Any]", "ZIO.succeed")
       }
@@ -178,6 +189,7 @@ object EndpointsView:
   def getApiEndpoints(starterDetails: StarterDetails): Code =
     val serverKind = starterDetails.serverEffect match {
       case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
+      case ServerEffect.Sync         => "List[ServerEndpoint[Any, Any]]"
       case ServerEffect.IOEffect     => "List[ServerEndpoint[Any, IO]]"
       case ServerEffect.ZIOEffect    => "List[ZServerEndpoint[Any, Any]]"
     }
@@ -231,6 +243,7 @@ object EndpointsView:
   private def serverEffectToEffectAndEndpoint(serverEffect: ServerEffect): (String, String) =
     serverEffect match {
       case ServerEffect.FutureEffect => ("Future", "ServerEndpoint[Any, Future]")
+      case ServerEffect.Sync         => ("Sync", "ServerEndpoint[Any, Any]")
       case ServerEffect.IOEffect     => ("IO", "ServerEndpoint[Any, IO]")
       case ServerEffect.ZIOEffect    => ("Task", "ZServerEndpoint[Any, Any]")
     }
@@ -244,6 +257,7 @@ object EndpointsView:
   def getAllEndpoints(starterDetails: StarterDetails): Code =
     val serverKind = starterDetails.serverEffect match {
       case ServerEffect.FutureEffect => "List[ServerEndpoint[Any, Future]]"
+      case ServerEffect.Sync         => "List[ServerEndpoint[Any, Any]]"
       case ServerEffect.IOEffect     => "List[ServerEndpoint[Any, IO]]"
       case ServerEffect.ZIOEffect    => "List[ZServerEndpoint[Any, Any]]"
     }

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/MainView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/MainView.scala
@@ -1,6 +1,6 @@
 package com.softwaremill.adopttapir.template.scala
 
-import com.softwaremill.adopttapir.starter.ServerEffect.{FutureEffect, IOEffect, ZIOEffect}
+import com.softwaremill.adopttapir.starter.ServerEffect.{FutureEffect, IOEffect, Sync, ZIOEffect}
 import com.softwaremill.adopttapir.starter.ServerImplementation.*
 import com.softwaremill.adopttapir.starter.{ScalaVersion, StarterDetails}
 
@@ -44,6 +44,8 @@ object MainView:
             txt.MainIOHttp4sScala3(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, IOEffect, Netty, addDocumentation, addMetrics, _, _, _) =>
             txt.MainIONettyScala3(groupId, addDocumentation, addMetrics).toString()
+          case StarterDetails(_, groupId, Sync, Netty, addDocumentation, addMetrics, _, _, _) =>
+            txt.MainSyncNettyScala3(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, IOEffect, VertX, addDocumentation, addMetrics, _, _, _) =>
             txt.MainIOVertxScala3(groupId, addDocumentation, addMetrics).toString()
           case StarterDetails(_, groupId, ZIOEffect, Http4s, addDocumentation, addMetrics, _, _, _) =>

--- a/backend/src/main/twirl/EndpointsSpecSync.scala.txt
+++ b/backend/src/main/twirl/EndpointsSpecSync.scala.txt
@@ -1,0 +1,56 @@
+@(
+starterDetails: com.softwaremill.adopttapir.starter.StarterDetails,
+additionalImports: List[com.softwaremill.adopttapir.template.scala.Import],
+helloStub: String,
+booksStub: String,
+scalaVersion: com.softwaremill.adopttapir.starter.ScalaVersion,
+jsonImplementation: com.softwaremill.adopttapir.starter.JsonImplementation,
+leftBracket: Char = '{',
+rightBracket: Char = '}'
+)
+package @{starterDetails.groupId}
+
+import @{starterDetails.groupId}.Endpoints.@leftBracket*,given@rightBracket
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client3.*
+import sttp.client3.testing.SttpBackendStub
+import sttp.tapir.server.stub.TapirStubInterpreter
+@for(additionalImport <- additionalImports) {
+@{additionalImport.asScalaImport(scalaVersion)}}
+
+class EndpointsSpec extends AnyFlatSpec with Matchers with EitherValues:
+@if(jsonImplementation == com.softwaremill.adopttapir.starter.JsonImplementation.Pickler){
+  given Reader[Author] = upickle.default.macroR
+  given Reader[Book] = upickle.default.macroR
+}
+
+  it should "return hello message" in {
+    // given
+    @helloStub
+
+    // when
+    val response = basicRequest
+      .get(uri"http://test.com/hello?name=adam")
+      .send(backendStub)
+
+    // then
+    response.body.value shouldBe "Hello adam"
+  }
+
+@if(booksStub.nonEmpty){
+  it should "list available books" in {
+    // given
+    @booksStub
+
+    // when
+    val response = basicRequest
+      .get(uri"http://test.com/books/list/all")
+      .response(asJson[List[Book]])
+      .send(backendStub)
+
+    // then
+    response.body.value shouldBe books
+  }
+}

--- a/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
@@ -14,7 +14,7 @@ import scala.io.StdIn
   }
   val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
   supervised {
-    val binding = useInScope(NettySyncServer(@if(addMetrics){serverOptions}).addEndpoints(Endpoints.all).start())(_.stop())
+    val binding = useInScope(NettySyncServer(@if(addMetrics){serverOptions}).port(port).addEndpoints(Endpoints.all).start())(_.stop())
     println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${binding.port}. }")
     // For demonstration puprposes, using ox.never is preferred to keep server running. See also NettySyncServer.startAndWait() for simpler approach:
     // (https://github.com/softwaremill/tapir/blob/master/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettySyncServer.scala)

--- a/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
@@ -14,7 +14,12 @@ import scala.io.StdIn
   }
   val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
   supervised {
-    val serverBinding = useInScope(NettySyncServer().addEndpoint(helloWorld).start())(_.stop())
+    val binding = useInScope(NettySyncServer(@if(addMetrics){serverOptions}).addEndpoints(Endpoints.all).start())(_.stop())
     println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${binding.port}. }")
-    never
+    // For demonstration puprposes, using ox.never is preferred to keep server running. See also NettySyncServer.startAndWait() for simpler approach:
+    // (https://github.com/softwaremill/tapir/blob/master/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettySyncServer.scala)
+    StdIn.readLine()
+
+    // Use ox.never instead of readLin
+    // never
   }

--- a/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
@@ -2,7 +2,7 @@
 package @groupId
 
 import ox.*
-import sttp.tapir.server.netty.@if(addMetrics){{NettySyncServer, NettySyncServerOptions}}else{NettySyncServer}
+import sttp.tapir.server.netty.sync.@if(addMetrics){{NettySyncServer, NettySyncServerOptions}}else{NettySyncServer}
 
 import scala.io.StdIn
 

--- a/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
@@ -4,8 +4,6 @@ package @groupId
 import ox.*
 import sttp.tapir.server.netty.sync.@if(addMetrics){{NettySyncServer, NettySyncServerOptions}}else{NettySyncServer}
 
-import scala.io.StdIn
-
 @@main def run(): Unit =
   @if(addMetrics) {
   val serverOptions = NettySyncServerOptions.customiseInterceptors
@@ -16,10 +14,5 @@ import scala.io.StdIn
   supervised {
     val binding = useInScope(NettySyncServer(@if(addMetrics){serverOptions}).port(port).addEndpoints(Endpoints.all).start())(_.stop())
     println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${binding.port}. }")
-    // For demonstration puprposes, using ox.never is preferred to keep server running. See also NettySyncServer.startAndWait() for simpler approach:
-    // (https://github.com/softwaremill/tapir/blob/master/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettySyncServer.scala)
-    StdIn.readLine()
-
-    // Use ox.never instead of readLin
-    // never
+    never
   }

--- a/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
@@ -1,0 +1,20 @@
+@(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
+package @groupId
+
+import ox.*
+import sttp.tapir.server.netty.@if(addMetrics){{NettySyncServer, NettySyncServerOptions}}else{NettySyncServer}
+
+import scala.io.StdIn
+
+@@main def run(): Unit =
+  @if(addMetrics) {
+  val serverOptions = NettySyncServerOptions.customiseInterceptors
+    .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+    .options
+  }
+  val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
+  supervised {
+    val serverBinding = useInScope(NettySyncServer().addEndpoint(helloWorld).start())(_.stop())
+    println(s"@if(addDocumentation){Go to http://localhost:${binding.port}/docs to open SwaggerUI. }else{Server started at http://localhost:${binding.port}. }")
+    never
+  }

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -35,7 +35,7 @@ object Setup:
       .getOrElse(elseAll)
 
   lazy val validConfigurations: Seq[StarterDetails] = for
-    effect <- EffectRequest.values.toIndexedSeq
+    effect <- effectImplementations
     server <- ServerImplementationRequest.values.toIndexedSeq
     docs <- List(true, false)
     metrics <- List(true, false)
@@ -61,6 +61,9 @@ object Setup:
 
   private lazy val scalaVersions: List[ScalaVersionRequest] =
     fromEnvOrElseAll("SCALA", ScalaVersionRequest.valueOf)(ScalaVersionRequest.values.toList)
+
+  private lazy val effectImplementations: List[EffectRequest] =
+    fromEnvOrElseAll("EFFECT", EffectRequest.valueOf)(EffectRequest.values.toList)
 
 object TestTimeouts:
   // wait for tests has to be longer than waiting for port otherwise it will break waiting for port with bogus errors

--- a/backend/src/test/scala/com/softwaremill/adopttapir/test/ServiceFactory.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/test/ServiceFactory.scala
@@ -8,7 +8,6 @@ import org.scalatest.Assertions
 import os.SubProcess
 
 import java.time.LocalDateTime
-import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.TimeoutException
@@ -67,10 +66,6 @@ abstract class GeneratedService:
     private val timestamp = LocalDateTime.now()
 
     override def toString: String = s"[$timestamp]"
-
-object ServiceFactory:
-  val port: AtomicInteger = new AtomicInteger(8080)
-  private def nextPortStr(): String = port.getAndIncrement().toString
 
 class ServiceFactory:
   import ServiceTimeouts.waitForScalaCliCompileAndUnitTest

--- a/backend/src/test/scala/com/softwaremill/adopttapir/test/ServiceFactory.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/test/ServiceFactory.scala
@@ -93,7 +93,7 @@ class ServiceFactory:
         // forward std input to forked process - https://www.scala-sbt.org/1.x/docs/Forking.html#Configuring+Input
         "set run / connectInput := true",
         ";compile ;test ;run"
-      ).spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> ServiceFactory.nextPortStr()), mergeErrIntoOut = true)
+      ).spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> "0"), mergeErrIntoOut = true)
     }
 
   private case class ScalaCliService(tempDir: better.files.File) extends GeneratedService:
@@ -110,4 +110,4 @@ class ServiceFactory:
       )
 
       os.proc("scala-cli", "--power", "run", ".")
-        .spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> ServiceFactory.nextPortStr()), mergeErrIntoOut = true)
+        .spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> "0"), mergeErrIntoOut = true)

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbtbuildinfo.{BuildInfoKey, BuildInfoOption}
 import scala.sys.process.Process
 import scala.util.Try
 
-val scala2Version = "2.13.13"
+val scala2Version = "2.13.14"
 val scala3Version = "3.3.3"
 
 val tapirVersion = "1.10.6"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbtbuildinfo.{BuildInfoKey, BuildInfoOption}
 import scala.sys.process.Process
 import scala.util.Try
 
-val scala2Version = "2.13.10"
+val scala2Version = "2.13.13"
 val scala3Version = "3.3.3"
 
 val tapirVersion = "1.10.6"

--- a/build.sbt
+++ b/build.sbt
@@ -258,6 +258,7 @@ lazy val templateDependencies: Project = project
       "com.softwaremill.sttp.tapir" %% "tapir-netty-server" % tapirVersion % Provided,
       "com.softwaremill.sttp.tapir" %% "tapir-cats" % tapirVersion % Provided,
       "com.softwaremill.sttp.tapir" %% "tapir-netty-server-cats" % tapirVersion % Provided,
+      "com.softwaremill.sttp.tapir" %% "tapir-netty-server-sync" % tapirVersion % Provided,
       "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % tapirVersion % Provided,
       "org.http4s" %% "http4s-ember-server" % http4sEmberServerVersion % Provided,
       "com.softwaremill.sttp.tapir" %% "tapir-http4s-server-zio" % tapirVersion % Provided,

--- a/ui/src/api/starter.ts
+++ b/ui/src/api/starter.ts
@@ -5,6 +5,7 @@ export enum EffectType {
   Future = 'FutureEffect',
   IO = 'IOEffect',
   ZIO = 'ZIOEffect',
+  Sync = 'Sync'
 }
 
 export enum EffectImplementation {

--- a/ui/src/api/starter.ts
+++ b/ui/src/api/starter.ts
@@ -5,7 +5,7 @@ export enum EffectType {
   Future = 'FutureEffect',
   IO = 'IOEffect',
   ZIO = 'ZIOEffect',
-  Sync = 'Sync'
+  Sync = 'Sync',
 }
 
 export enum EffectImplementation {

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -244,10 +244,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
 
           <fieldset className={classes.groupedInputs}>
             <legend className={classes.groupLegend}>Server</legend>
-            <FormSelect
-              name="effect"
-              label="Effect type"
-              options={ getEffectTypeOptions(scalaVersion) } />
+            <FormSelect name="effect" label="Effect type" options={getEffectTypeOptions(scalaVersion)} />
             <div className={classes.inputWithAddon}>
               <FormSelect
                 name="implementation"

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -22,7 +22,6 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
 import {
   BUILDER_OPTIONS,
-  EFFECT_TYPE_OPTIONS,
   ENDPOINTS_OPTIONS,
   SCALA_VERSION_OPTIONS,
   starterValidationSchema,
@@ -30,8 +29,10 @@ import {
 import {
   getAvailableEffectImplementations,
   getEffectImplementationOptions,
+  getEffectTypeOptions,
   getJSONImplementationOptions,
   mapEffectTypeToJSONImplementation,
+  mapScalaVersionToEffectType,
   mapScalaVersionToJSONImplementation,
 } from './ConfigurationForm.helpers';
 import { useNavigate } from 'react-router-dom';
@@ -120,6 +121,13 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
     'scalaVersion',
   ]);
   const isEffectImplementationSelectable = Boolean(effectType) && Boolean(scalaVersion);
+
+  useEffect(() => {
+    // NOTE: reset effect type field value upon scala version change
+    if (effectType && scalaVersion && !mapScalaVersionToEffectType(scalaVersion).includes(effectType)) {
+      form.resetField('effect');
+    }
+  }, [form, effectType, effectImplementation, scalaVersion]);
 
   useEffect(() => {
     // NOTE: reset effect implementation field value upon effect type or scala version change
@@ -236,7 +244,10 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
 
           <fieldset className={classes.groupedInputs}>
             <legend className={classes.groupLegend}>Server</legend>
-            <FormSelect name="effect" label="Effect type" options={EFFECT_TYPE_OPTIONS} />
+            <FormSelect
+              name="effect"
+              label="Effect type"
+              options={ getEffectTypeOptions(scalaVersion) } />
             <div className={classes.inputWithAddon}>
               <FormSelect
                 name="implementation"

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
@@ -37,6 +37,10 @@ export const EFFECT_TYPE_OPTIONS: FormSelectOption<EffectType>[] = [
     value: EffectType.IO,
   },
   {
+    label: 'Sync (direct-style)',
+    value: EffectType.Sync,
+  },
+  {
     label: 'ZIO',
     value: EffectType.ZIO,
   },

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.consts.ts
@@ -152,18 +152,18 @@ export const starterValidationSchema = yup
       )
       .max(256, 'Group ID length should be smaller than 256 characters')
       .required(REQUIRED_FIELD_MESSAGE),
-    effect: yup
-      .mixed()
-      .oneOf(
-        EFFECT_TYPE_OPTIONS.map(valueGetter),
-        `Effect type must be one of the following values: ${EFFECT_TYPE_OPTIONS.map(labelGetter).join(', ')}`
-      )
-      .required(REQUIRED_FIELD_MESSAGE),
     scalaVersion: yup
       .mixed()
       .oneOf(
         SCALA_VERSION_OPTIONS.map(valueGetter),
         `Scala version must be one of the following values: ${SCALA_VERSION_OPTIONS.map(labelGetter).join(', ')}`
+      )
+      .required(REQUIRED_FIELD_MESSAGE),
+    effect: yup
+      .mixed()
+      .oneOf(
+        EFFECT_TYPE_OPTIONS.map(valueGetter),
+        `Effect type must be one of the following values: ${EFFECT_TYPE_OPTIONS.map(labelGetter).join(', ')}`
       )
       .required(REQUIRED_FIELD_MESSAGE),
     implementation: yup

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.helpers.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.helpers.ts
@@ -1,5 +1,5 @@
 import { EffectImplementation, EffectType, JSONImplementation, ScalaVersion } from 'api/starter';
-import { EFFECT_IMPLEMENTATIONS_OPTIONS, JSON_OUTPUT_OPTIONS } from './ConfigurationForm.consts';
+import { EFFECT_IMPLEMENTATIONS_OPTIONS, EFFECT_TYPE_OPTIONS, JSON_OUTPUT_OPTIONS } from './ConfigurationForm.consts';
 import type { FormSelectOption } from '../FormSelect';
 import type { FormRadioOption } from '../FormRadioGroup';
 
@@ -19,6 +19,11 @@ const effectTypeImplementationMap: Record<EffectType, EffectImplementation[]> = 
   ],
 };
 
+const versionTypeEffectImplementationMap: Record<ScalaVersion, EffectType[]> = {
+  [ScalaVersion.Scala2]: [EffectType.Future, EffectType.IO, EffectType.ZIO],
+  [ScalaVersion.Scala3]: [EffectType.Future, EffectType.IO, EffectType.Sync, EffectType.ZIO],
+};
+
 const mapEffectTypeToEffectImplementation = (effectType: EffectType): EffectImplementation[] => {
   return effectTypeImplementationMap[effectType];
 };
@@ -26,6 +31,19 @@ const mapEffectTypeToEffectImplementation = (effectType: EffectType): EffectImpl
 export const getAvailableEffectImplementations = (effectType: EffectType): EffectImplementation[] => {
   const availableEffectImplementations = mapEffectTypeToEffectImplementation(effectType);
   return availableEffectImplementations === undefined ? [] : availableEffectImplementations;
+};
+
+export const mapScalaVersionToEffectType = (scalaVersion: ScalaVersion): EffectType[] => {
+  return versionTypeEffectImplementationMap[scalaVersion];
+};
+
+const getEffectTypes = (scalaVersion?: ScalaVersion): EffectType[] => {
+  return scalaVersion ? mapScalaVersionToEffectType(scalaVersion) : Object.values(EffectType);
+};
+
+export const getEffectTypeOptions = (scalaVersion?: ScalaVersion): FormSelectOption[] => {
+  const effectTypes = getEffectTypes(scalaVersion);
+  return EFFECT_TYPE_OPTIONS.filter(({ value }) => effectTypes.includes(value));
 };
 
 export const getEffectImplementationOptions = (effectType: EffectType): FormSelectOption[] => {

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.helpers.ts
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.helpers.ts
@@ -10,6 +10,7 @@ import type { FormRadioOption } from '../FormRadioGroup';
 const effectTypeImplementationMap: Record<EffectType, EffectImplementation[]> = {
   [EffectType.Future]: [EffectImplementation.Netty, EffectImplementation.VertX, EffectImplementation.Pekko],
   [EffectType.IO]: [EffectImplementation.Http4s, EffectImplementation.Netty, EffectImplementation.VertX],
+  [EffectType.Sync]: [EffectImplementation.Netty],
   [EffectType.ZIO]: [
     EffectImplementation.Netty,
     EffectImplementation.Http4s,
@@ -47,6 +48,7 @@ const commonJSONImplementations: JSONImplementation[] = [
 const effectTypeJsonImplementationMap: Record<EffectType, JSONImplementation[]> = {
   [EffectType.Future]: commonJSONImplementations,
   [EffectType.IO]: commonJSONImplementations,
+  [EffectType.Sync]: commonJSONImplementations,
   [EffectType.ZIO]: commonJSONImplementations.concat(JSONImplementation.ZIOJson),
 };
 

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.consts.test.ts
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.consts.test.ts
@@ -93,6 +93,7 @@ describe('configuration consts', () => {
         { effectType: EffectType.Future, expected: true },
         { effectType: EffectType.IO, expected: true },
         { effectType: EffectType.ZIO, expected: true },
+        { effectType: EffectType.Sync, expected: true },
         { effectType: 'notValidEffect' as EffectType, expected: false },
         { effectType: '' as EffectType, expected: false },
         { effectType: undefined, expected: false },
@@ -156,6 +157,11 @@ describe('configuration consts', () => {
         [EffectType.IO, ScalaVersion.Scala3, EffectImplementation.Netty, true],
         [EffectType.IO, ScalaVersion.Scala3, EffectImplementation.Http4s, true],
         [EffectType.IO, ScalaVersion.Scala3, EffectImplementation.ZIOHttp, false],
+
+        [EffectType.Sync, ScalaVersion.Scala3, EffectImplementation.Netty, true],
+        [EffectType.Sync, ScalaVersion.Scala3, EffectImplementation.Http4s, false],
+        [EffectType.Sync, ScalaVersion.Scala3, EffectImplementation.ZIOHttp, false],
+        [EffectType.Sync, ScalaVersion.Scala3, EffectImplementation.Pekko, false],
 
         [EffectType.ZIO, ScalaVersion.Scala3, EffectImplementation.Netty, true],
         [EffectType.ZIO, ScalaVersion.Scala3, EffectImplementation.Http4s, true],
@@ -242,6 +248,13 @@ describe('configuration consts', () => {
         [ScalaVersion.Scala3, EffectType.IO, JSONImplementation.Jsoniter, true],
         [ScalaVersion.Scala3, EffectType.IO, JSONImplementation.ZIOJson, false],
         [ScalaVersion.Scala3, EffectType.IO, JSONImplementation.Pickler, true],
+
+        [ScalaVersion.Scala3, EffectType.Sync, JSONImplementation.No, true],
+        [ScalaVersion.Scala3, EffectType.Sync, JSONImplementation.Circe, true],
+        [ScalaVersion.Scala3, EffectType.Sync, JSONImplementation.UPickle, true],
+        [ScalaVersion.Scala3, EffectType.Sync, JSONImplementation.Jsoniter, true],
+        [ScalaVersion.Scala3, EffectType.Sync, JSONImplementation.ZIOJson, false],
+        [ScalaVersion.Scala3, EffectType.Sync, JSONImplementation.Pickler, true],
 
         [ScalaVersion.Scala3, EffectType.ZIO, JSONImplementation.No, true],
         [ScalaVersion.Scala3, EffectType.ZIO, JSONImplementation.Circe, true],

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.helpers.test.ts
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.helpers.test.ts
@@ -166,8 +166,8 @@ describe('configuration form helpers', () => {
           {
             label: 'Netty',
             value: EffectImplementation.Netty,
-          }
-        ]
+          },
+        ],
       ],
       [
         EffectType.ZIO,

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.helpers.test.ts
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.helpers.test.ts
@@ -41,6 +41,7 @@ describe('configuration form helpers', () => {
         ScalaVersion.Scala3,
         [EffectImplementation.Http4s, EffectImplementation.Netty, EffectImplementation.VertX],
       ],
+      [EffectType.Sync, ScalaVersion.Scala3, [EffectImplementation.Netty]],
       [
         EffectType.ZIO,
         ScalaVersion.Scala3,
@@ -157,6 +158,16 @@ describe('configuration form helpers', () => {
             value: EffectImplementation.VertX,
           },
         ],
+      ],
+      [
+        EffectType.Sync,
+        ScalaVersion.Scala3,
+        [
+          {
+            label: 'Netty',
+            value: EffectImplementation.Netty,
+          }
+        ]
       ],
       [
         EffectType.ZIO,
@@ -297,6 +308,32 @@ describe('configuration form helpers', () => {
       [
         ScalaVersion.Scala3,
         EffectType.IO,
+        [
+          {
+            label: "don't add",
+            value: JSONImplementation.No,
+          },
+          {
+            label: 'circe',
+            value: JSONImplementation.Circe,
+          },
+          {
+            label: 'µPickle',
+            value: JSONImplementation.UPickle,
+          },
+          {
+            label: 'pickler',
+            value: JSONImplementation.Pickler,
+          },
+          {
+            label: 'jsoniter',
+            value: JSONImplementation.Jsoniter,
+          },
+        ],
+      ],
+      [
+        ScalaVersion.Scala3,
+        EffectType.Sync,
         [
           {
             label: "don't add",


### PR DESCRIPTION
This PR adds the `tapir-netty-sync` backend. It appears as a separate `Sync` effect type, available only for `Netty` and `Scala 3`. This backend has no "effect" per se, it's the direct-style monadless one, based on Netty and Loom. In order to test this properly, I added a new CI matrix axis for the effect. As a result, quite a lot of parallel builds are generated, but the overall build time doesn't increase (it's actually faster: ~13m instead of ~25m).
Additionally, I bumbed JDK to 21 in the workflow, leaving Java 17 for integration tests with effect != "Sync".