### PR TITLE
Change metrics from prometheus to opentelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To start the frontend:
 ```
 
 Please notice, that by default fronted points to the production backend.
-This could be changed by specifying the `REACT_APP_SERVER_ADDRESS` environmental variable.
+This could be changed by specifying the `VITE_SERVER_ADDRESS` environmental variable.
 To start the frontend pointing to `http://localhost:9090` run:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ export VITE_SERVER_ADDRESS="http://localhost:9090"; ./frontend-start.sh
 
 ## Copyright
 
-Copyright (C) 2013-2025 SoftwareMill [https://softwaremill.com](https://softwaremill.com).
+Copyright (C) 2013-2026 SoftwareMill [https://softwaremill.com](https://softwaremill.com).

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/BuildView.scala
@@ -45,8 +45,13 @@ abstract class BuildView:
       List(ScalaDependency("com.softwaremill.sttp.tapir", "tapir-swagger-ui-bundle", getTapirVersion()))
     else Nil
 
-  private def getMetricsDependencies(starterDetails: StarterDetails): List[ScalaDependency] =
-    if starterDetails.addMetrics then List(ScalaDependency("com.softwaremill.sttp.tapir", "tapir-prometheus-metrics", getTapirVersion()))
+  private def getMetricsDependencies(starterDetails: StarterDetails): List[Dependency] =
+    if starterDetails.addMetrics then
+      List(
+        ScalaDependency("com.softwaremill.sttp.tapir", "tapir-opentelemetry-metrics", getTapirVersion()),
+        JavaDependency("io.opentelemetry", "opentelemetry-exporter-otlp", TemplateDependencyInfo.opentelemetryVersion),
+        JavaDependency("io.opentelemetry", "opentelemetry-sdk-extension-autoconfigure", TemplateDependencyInfo.opentelemetryVersion)
+      )
     else Nil
 
   private def getLoggerDependency(starterDetails: StarterDetails): List[Dependency] =

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/ProjectGenerator.scala
@@ -51,7 +51,7 @@ abstract class ProjectTemplate:
     val library = EndpointsView.getJsonLibrary(starterDetails)
     val apiEndpoints = EndpointsView.getApiEndpoints(starterDetails)
     val docEndpoints = EndpointsView.getDocEndpoints(starterDetails)
-    val metricsEndpoint = EndpointsView.getMetricsEndpoint(starterDetails)
+    val metricsDefinition = EndpointsView.getMetricsDefinition(starterDetails)
     val allEndpoints = EndpointsView.getAllEndpoints(starterDetails)
 
     GeneratedFile(
@@ -60,7 +60,7 @@ abstract class ProjectTemplate:
         .Endpoints(
           starterDetails = starterDetails,
           additionalImports = toSortedList(
-            helloServerEndpoint.imports ++ metricsEndpoint.imports ++ docEndpoints.imports
+            helloServerEndpoint.imports ++ metricsDefinition.imports ++ docEndpoints.imports
               ++ jsonEndpoint.imports ++ library.imports ++ allEndpoints.imports
           ),
           helloEndpointServer = helloServerEndpoint.body,
@@ -68,7 +68,7 @@ abstract class ProjectTemplate:
           library = library.body,
           apiEndpoints = apiEndpoints.body,
           docEndpoints = docEndpoints.body,
-          metricsEndpoint = metricsEndpoint.body,
+          metricsDefinition = metricsDefinition.body,
           allEndpoints = allEndpoints.body,
           scalaVersion = starterDetails.scalaVersion
         )
@@ -223,7 +223,7 @@ private object ScalaCliSingleFileTemplate:
     val library = EndpointsView.getJsonLibrary(starterDetails)
     val apiEndpoints = EndpointsView.getApiEndpoints(starterDetails)
     val docEndpoints = EndpointsView.getDocEndpoints(starterDetails)
-    val metricsEndpoint = EndpointsView.getMetricsEndpoint(starterDetails)
+    val metricsDefinition = EndpointsView.getMetricsDefinition(starterDetails)
     val allEndpoints = EndpointsView.getAllEndpoints(starterDetails)
     val mainContentRaw = MainView.getProperMainContent(starterDetails)
 
@@ -231,7 +231,7 @@ private object ScalaCliSingleFileTemplate:
     val (mainImports, mainContent) = extractImportsAndContent(mainContentRaw)
 
     val allImports = toSortedList(
-      helloServerEndpoint.imports ++ metricsEndpoint.imports ++ docEndpoints.imports
+      helloServerEndpoint.imports ++ metricsDefinition.imports ++ docEndpoints.imports
         ++ jsonEndpoint.imports ++ library.imports ++ allEndpoints.imports ++ mainImports
     )
 
@@ -247,7 +247,7 @@ private object ScalaCliSingleFileTemplate:
         library.body,
         apiEndpoints.body,
         docEndpoints.body,
-        metricsEndpoint.body,
+        metricsDefinition.body,
         allEndpoints.body,
         mainContent,
         starterDetails.scalaVersion

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
@@ -230,20 +230,24 @@ object EndpointsView:
     def prepareImports(serverStack: ServerStack): Set[Import] =
       serverStackImports(serverStack) + Import("sttp.tapir.swagger.bundle.SwaggerInterpreter")
 
-  def getMetricsEndpoint(starterDetails: StarterDetails): Code =
+  def getMetricsDefinition(starterDetails: StarterDetails): Code =
     if starterDetails.addMetrics then {
-      MetricsEndpoint.prepareMetricsEndpoint(starterDetails.serverStack)
+      MetricsDefinition.prepareMetricsDefinition(starterDetails)
     } else {
       Code.empty
     }
 
-  private object MetricsEndpoint:
-    def prepareMetricsEndpoint(serverStack: ServerStack): Code =
-      val (effect, endpoint) = serverStackToEffectAndEndpoint(serverStack)
+  private object MetricsDefinition:
+    def prepareMetricsDefinition(starterDetails: StarterDetails): Code =
+      val serverStack = starterDetails.serverStack
+      val (effect, _) = serverStackToEffectAndEndpoint(serverStack)
       Code(
-        s"${INDENT}val prometheusMetrics: PrometheusMetrics[$effect] = PrometheusMetrics.default[$effect]()" + NEW_LINE_WITH_INDENT +
-          s"val metricsEndpoint: $endpoint = prometheusMetrics.metricsEndpoint",
-        serverStackImports(serverStack) + Import("sttp.tapir.server.metrics.prometheus.PrometheusMetrics")
+        s"${INDENT}val otel: OpenTelemetry = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk" + NEW_LINE_WITH_INDENT +
+          s"val $otelMetrics: OpenTelemetryMetrics[$effect] = OpenTelemetryMetrics.default[$effect](otel.getMeter(\"${starterDetails.projectName}\"))",
+        serverStackImports(serverStack) +
+          Import("io.opentelemetry.api.OpenTelemetry") +
+          Import("io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk") +
+          Import("sttp.tapir.server.metrics.opentelemetry.OpenTelemetryMetrics")
       )
 
   private def serverStackToEffectAndEndpoint(serverStack: ServerStack): (String, String) =
@@ -268,14 +272,13 @@ object EndpointsView:
       case ServerStack.ZIOStack    => "List[ZServerEndpoint[Any, Any]]"
     }
 
-    def bodyTemplate(serverKind: String, addMetrics: Boolean, hasDocumentation: Boolean): String = {
+    def bodyTemplate(serverKind: String, hasDocumentation: Boolean): String = {
       s"val ${Constants.all}: $serverKind = $apiEndpoints" +
-        s"${if hasDocumentation then s" ++ $docEndpoints" else ""}" +
-        s"${if addMetrics then s" ++ List($metricsEndpoint)" else ""}"
+        s"${if hasDocumentation then s" ++ $docEndpoints" else ""}"
 
     }
 
-    Code(bodyTemplate(serverKind, starterDetails.addMetrics, starterDetails.addDocumentation)).prependBody(INDENT)
+    Code(bodyTemplate(serverKind, starterDetails.addDocumentation)).prependBody(INDENT)
 
   object Constants:
     val INDENT: String = " " * 2
@@ -286,5 +289,5 @@ object EndpointsView:
     val booksListingServerEndpoint = "booksListingServerEndpoint"
     val apiEndpoints = "apiEndpoints"
     val docEndpoints = "docEndpoints"
-    val metricsEndpoint = "metricsEndpoint"
+    val otelMetrics = "otelMetrics"
     val all = "all"

--- a/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/template/scala/EndpointsView.scala
@@ -242,11 +242,10 @@ object EndpointsView:
       val serverStack = starterDetails.serverStack
       val (effect, _) = serverStackToEffectAndEndpoint(serverStack)
       Code(
-        s"${INDENT}val otel: OpenTelemetry = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk" + NEW_LINE_WITH_INDENT +
-          s"val $otelMetrics: OpenTelemetryMetrics[$effect] = OpenTelemetryMetrics.default[$effect](otel.getMeter(\"${starterDetails.projectName}\"))",
+        s"${INDENT}def $metricsInterceptor(otel: OpenTelemetry) =" + NEW_LINE_WITH_INDENT +
+          s"  OpenTelemetryMetrics.default[$effect](otel.getMeter(\"${starterDetails.projectName}\")).metricsInterceptor()",
         serverStackImports(serverStack) +
           Import("io.opentelemetry.api.OpenTelemetry") +
-          Import("io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk") +
           Import("sttp.tapir.server.metrics.opentelemetry.OpenTelemetryMetrics")
       )
 
@@ -289,5 +288,5 @@ object EndpointsView:
     val booksListingServerEndpoint = "booksListingServerEndpoint"
     val apiEndpoints = "apiEndpoints"
     val docEndpoints = "docEndpoints"
-    val otelMetrics = "otelMetrics"
+    val metricsInterceptor = "metricsInterceptor"
     val all = "all"

--- a/backend/src/main/twirl/Endpoints.scala.txt
+++ b/backend/src/main/twirl/Endpoints.scala.txt
@@ -6,7 +6,7 @@ jsonEndpoint: String,
 library: String,
 apiEndpoints: String,
 docEndpoints: String,
-metricsEndpoint: String,
+metricsDefinition: String,
 allEndpoints: String,
 scalaVersion: com.softwaremill.adopttapir.starter.ScalaVersion,
 leftBracket: Char = '{',
@@ -32,7 +32,7 @@ object Endpoints@if(scalaVersion == com.softwaremill.adopttapir.starter.ScalaVer
 
 @docEndpoints
 
-@metricsEndpoint
+@metricsDefinition
 
 @allEndpoints
 @if(scalaVersion == com.softwaremill.adopttapir.starter.ScalaVersion.Scala2){@rightBracket}

--- a/backend/src/main/twirl/MainFutureNetty.scala.txt
+++ b/backend/src/main/twirl/MainFutureNetty.scala.txt
@@ -12,7 +12,7 @@ object Main {
   def main(args: Array[String]): Unit = {
     @if(addMetrics) {
     val serverOptions = NettyFutureServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
       .options
     }
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)

--- a/backend/src/main/twirl/MainFutureNetty.scala.txt
+++ b/backend/src/main/twirl/MainFutureNetty.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import sttp.tapir.server.netty.@if(addMetrics){{NettyFutureServer, NettyFutureServerOptions}}else{NettyFutureServer}
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.netty.@if(addMetrics){{NettyFutureServer, NettyFutureServerOptions}}else{NettyFutureServer}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -11,8 +12,9 @@ import scala.io.StdIn
 object Main {
   def main(args: Array[String]): Unit = {
     @if(addMetrics) {
+    val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
     val serverOptions = NettyFutureServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.metricsInterceptor(otel))
       .options
     }
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)

--- a/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
@@ -10,7 +10,7 @@ import scala.io.StdIn
 
 @@main def run(): Unit =
   @if(addMetrics){val serverOptions = NettyFutureServerOptions.customiseInterceptors
-    .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+    .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
     .options
   }val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
   val program =

--- a/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainFutureNettyScala3.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import sttp.tapir.server.netty.@if(addMetrics){{NettyFutureServer, NettyFutureServerOptions}}else{NettyFutureServer}
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.netty.@if(addMetrics){{NettyFutureServer, NettyFutureServerOptions}}else{NettyFutureServer}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -9,8 +10,9 @@ import scala.concurrent.{Await, Future}
 import scala.io.StdIn
 
 @@main def run(): Unit =
-  @if(addMetrics){val serverOptions = NettyFutureServerOptions.customiseInterceptors
-    .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+  @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+  val serverOptions = NettyFutureServerOptions.customiseInterceptors
+    .metricsInterceptor(Endpoints.metricsInterceptor(otel))
     .options
   }val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
   val program =

--- a/backend/src/main/twirl/MainFuturePekko.scala.txt
+++ b/backend/src/main/twirl/MainFuturePekko.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import org.apache.pekko.actor.ActorSystem
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import sttp.tapir.server.pekkohttp.@if(addMetrics){{PekkoHttpServerInterpreter, PekkoHttpServerOptions}}else{PekkoHttpServerInterpreter}
 
@@ -14,9 +15,10 @@ object Main {
     implicit val actorSystem: ActorSystem = ActorSystem()
 
     @if(addMetrics) {
+    val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
     val serverOptions: PekkoHttpServerOptions =
       PekkoHttpServerOptions.customiseInterceptors
-        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.metricsInterceptor(otel))
         .options
 
     val route = PekkoHttpServerInterpreter(serverOptions).toRoute(Endpoints.all)

--- a/backend/src/main/twirl/MainFuturePekko.scala.txt
+++ b/backend/src/main/twirl/MainFuturePekko.scala.txt
@@ -16,7 +16,7 @@ object Main {
     @if(addMetrics) {
     val serverOptions: PekkoHttpServerOptions =
       PekkoHttpServerOptions.customiseInterceptors
-        .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
         .options
 
     val route = PekkoHttpServerInterpreter(serverOptions).toRoute(Endpoints.all)

--- a/backend/src/main/twirl/MainFuturePekkoScala3.scala.txt
+++ b/backend/src/main/twirl/MainFuturePekkoScala3.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import org.apache.pekko.actor.ActorSystem
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import sttp.tapir.server.pekkohttp.@if(addMetrics){{PekkoHttpServerInterpreter, PekkoHttpServerOptions}}else{PekkoHttpServerInterpreter}
 
@@ -12,9 +13,10 @@ import scala.io.StdIn
   implicit val actorSystem: ActorSystem = ActorSystem()
 
   @if(addMetrics) {
+  val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
   val serverOptions: PekkoHttpServerOptions =
     PekkoHttpServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.metricsInterceptor(otel))
       .options
 
   val route = PekkoHttpServerInterpreter(serverOptions).toRoute(Endpoints.all)

--- a/backend/src/main/twirl/MainFuturePekkoScala3.scala.txt
+++ b/backend/src/main/twirl/MainFuturePekkoScala3.scala.txt
@@ -14,7 +14,7 @@ import scala.io.StdIn
   @if(addMetrics) {
   val serverOptions: PekkoHttpServerOptions =
     PekkoHttpServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
       .options
 
   val route = PekkoHttpServerInterpreter(serverOptions).toRoute(Endpoints.all)

--- a/backend/src/main/twirl/MainFutureVertx.scala.txt
+++ b/backend/src/main/twirl/MainFutureVertx.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import io.vertx.core.Vertx
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import io.vertx.core.Vertx
 import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.@if(addMetrics){{VertxFutureServerInterpreter, VertxFutureServerOptions}}else{VertxFutureServerInterpreter}
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter.VertxFutureToScalaFuture
@@ -15,8 +16,9 @@ import scala.io.StdIn
 object Main {
   def main(args: Array[String]): Unit = {
     @if(addMetrics) {
+    val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
     val serverOptions = VertxFutureServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.metricsInterceptor(otel))
       .options
     }
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)

--- a/backend/src/main/twirl/MainFutureVertx.scala.txt
+++ b/backend/src/main/twirl/MainFutureVertx.scala.txt
@@ -16,7 +16,7 @@ object Main {
   def main(args: Array[String]): Unit = {
     @if(addMetrics) {
     val serverOptions = VertxFutureServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
       .options
     }
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)

--- a/backend/src/main/twirl/MainFutureVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainFutureVertxScala3.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import io.vertx.core.Vertx
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import io.vertx.core.Vertx
 import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.@if(addMetrics){{VertxFutureServerInterpreter, VertxFutureServerOptions}}else{VertxFutureServerInterpreter}
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter.VertxFutureToScalaFuture
@@ -13,8 +14,9 @@ import scala.io.StdIn
 
 
 @@main def run(): Unit =
-  @if(addMetrics){val serverOptions = VertxFutureServerOptions.customiseInterceptors
-    .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+  @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+  val serverOptions = VertxFutureServerOptions.customiseInterceptors
+    .metricsInterceptor(Endpoints.metricsInterceptor(otel))
     .options
   }val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 

--- a/backend/src/main/twirl/MainFutureVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainFutureVertxScala3.scala.txt
@@ -14,7 +14,7 @@ import scala.io.StdIn
 
 @@main def run(): Unit =
   @if(addMetrics){val serverOptions = VertxFutureServerOptions.customiseInterceptors
-    .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+    .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
     .options
   }val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 

--- a/backend/src/main/twirl/MainIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4s.scala.txt
@@ -3,16 +3,18 @@ package @groupId
 
 import cats.effect.{ExitCode, IO, IOApp}
 import com.comcast.ip4s.{Host, IpLiteralSyntax, Port}
-import org.http4s.ember.server.EmberServerBuilder
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router
 import sttp.tapir.server.http4s.@if(addMetrics){{Http4sServerInterpreter, Http4sServerOptions}}else{Http4sServerInterpreter}
 
 object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
-    @if(addMetrics){val serverOptions: Http4sServerOptions[IO] =
+    @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+    val serverOptions: Http4sServerOptions[IO] =
       Http4sServerOptions.customiseInterceptors[IO]
-        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.metricsInterceptor(otel))
         .options
     val routes = Http4sServerInterpreter[IO](serverOptions).toRoutes(Endpoints.all)
     }else{val routes = Http4sServerInterpreter[IO]().toRoutes(Endpoints.all)

--- a/backend/src/main/twirl/MainIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4s.scala.txt
@@ -12,7 +12,7 @@ object Main extends IOApp {
   override def run(args: List[String]): IO[ExitCode] = {
     @if(addMetrics){val serverOptions: Http4sServerOptions[IO] =
       Http4sServerOptions.customiseInterceptors[IO]
-        .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
         .options
     val routes = Http4sServerInterpreter[IO](serverOptions).toRoutes(Endpoints.all)
     }else{val routes = Http4sServerInterpreter[IO]().toRoutes(Endpoints.all)

--- a/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
@@ -12,7 +12,7 @@ object Main extends IOApp:
   override def run(args: List[String]): IO[ExitCode] =
     @if(addMetrics){val serverOptions: Http4sServerOptions[IO] =
       Http4sServerOptions.customiseInterceptors[IO]
-        .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
         .options
     val routes = Http4sServerInterpreter[IO](serverOptions).toRoutes(Endpoints.all)
     }else{val routes = Http4sServerInterpreter[IO]().toRoutes(Endpoints.all)

--- a/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainIOHttp4sScala3.scala.txt
@@ -3,16 +3,18 @@ package @groupId
 
 import cats.effect.{ExitCode, IO, IOApp}
 import com.comcast.ip4s.{Host, Port, port}
-import org.http4s.ember.server.EmberServerBuilder
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router
 import sttp.tapir.server.http4s.@if(addMetrics){{Http4sServerInterpreter, Http4sServerOptions}}else{Http4sServerInterpreter}
 
 object Main extends IOApp:
 
   override def run(args: List[String]): IO[ExitCode] =
-    @if(addMetrics){val serverOptions: Http4sServerOptions[IO] =
+    @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+    val serverOptions: Http4sServerOptions[IO] =
       Http4sServerOptions.customiseInterceptors[IO]
-        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.metricsInterceptor(otel))
         .options
     val routes = Http4sServerInterpreter[IO](serverOptions).toRoutes(Endpoints.all)
     }else{val routes = Http4sServerInterpreter[IO]().toRoutes(Endpoints.all)

--- a/backend/src/main/twirl/MainIONetty.scala.txt
+++ b/backend/src/main/twirl/MainIONetty.scala.txt
@@ -3,7 +3,8 @@ package @groupId
 
 @if(addMetrics){import cats.effect.std.Dispatcher}
 import cats.effect.{ExitCode, IO, IOApp}
-import sttp.tapir.server.netty.cats.@if(addMetrics){{NettyCatsServer, NettyCatsServerOptions}}else{NettyCatsServer}
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.netty.cats.@if(addMetrics){{NettyCatsServer, NettyCatsServerOptions}}else{NettyCatsServer}
 
 object Main extends IOApp {
 
@@ -11,9 +12,10 @@ object Main extends IOApp {
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
     @if(addMetrics){
+      val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
       Dispatcher[IO].map( d => { NettyCatsServer.apply[IO]({
         NettyCatsServerOptions.customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.metricsInterceptor(otel))
           .options
       }) })
     } else {

--- a/backend/src/main/twirl/MainIONetty.scala.txt
+++ b/backend/src/main/twirl/MainIONetty.scala.txt
@@ -13,7 +13,7 @@ object Main extends IOApp {
     @if(addMetrics){
       Dispatcher[IO].map( d => { NettyCatsServer.apply[IO]({
         NettyCatsServerOptions.customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
           .options
       }) })
     } else {

--- a/backend/src/main/twirl/MainIONettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainIONettyScala3.scala.txt
@@ -12,7 +12,7 @@ object Main extends IOApp:
     @if(addMetrics){
       Dispatcher[IO].map( d => { NettyCatsServer.apply[IO]({
         NettyCatsServerOptions.customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
           .options
       }) })
     } else {

--- a/backend/src/main/twirl/MainIONettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainIONettyScala3.scala.txt
@@ -3,16 +3,18 @@ package @groupId
 
 @if(addMetrics){import cats.effect.std.Dispatcher}
 import cats.effect.{ExitCode, IO, IOApp}
-import sttp.tapir.server.netty.cats.@if(addMetrics){{NettyCatsServer, NettyCatsServerOptions}}else{NettyCatsServer}
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.netty.cats.@if(addMetrics){{NettyCatsServer, NettyCatsServerOptions}}else{NettyCatsServer}
 
 object Main extends IOApp:
   val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
 
   override def run(args: List[String]): IO[ExitCode] =
     @if(addMetrics){
+      val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
       Dispatcher[IO].map( d => { NettyCatsServer.apply[IO]({
         NettyCatsServerOptions.customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.metricsInterceptor(otel))
           .options
       }) })
     } else {

--- a/backend/src/main/twirl/MainIOVertx.scala.txt
+++ b/backend/src/main/twirl/MainIOVertx.scala.txt
@@ -3,7 +3,8 @@ package @groupId
 
 import cats.effect._
 import cats.effect.std.Dispatcher
-import io.vertx.core.Vertx
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import io.vertx.core.Vertx
 import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.cats.@if(addMetrics){{VertxCatsServerInterpreter, VertxCatsServerOptions}}else{VertxCatsServerInterpreter}
 import sttp.tapir.server.vertx.cats.VertxCatsServerInterpreter._
@@ -20,9 +21,10 @@ object Main extends IOApp {
     Dispatcher[IO]
       @if(addMetrics) {
       .map(d => {
+        val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
         VertxCatsServerOptions
           .customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.metricsInterceptor(otel))
           .options
       })
       }

--- a/backend/src/main/twirl/MainIOVertx.scala.txt
+++ b/backend/src/main/twirl/MainIOVertx.scala.txt
@@ -22,7 +22,7 @@ object Main extends IOApp {
       .map(d => {
         VertxCatsServerOptions
           .customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
           .options
       })
       }

--- a/backend/src/main/twirl/MainIOVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainIOVertxScala3.scala.txt
@@ -3,7 +3,8 @@ package @groupId
 
 import cats.effect._
 import cats.effect.std.Dispatcher
-import io.vertx.core.Vertx
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import io.vertx.core.Vertx
 import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.cats.@if(addMetrics){{VertxCatsServerInterpreter, VertxCatsServerOptions}}else{VertxCatsServerInterpreter}
 import sttp.tapir.server.vertx.cats.VertxCatsServerInterpreter._
@@ -19,10 +20,11 @@ object Main extends IOApp:
 
     Dispatcher[IO]
       @if(addMetrics) {
-      .map: d => 
+      .map: d =>
+        val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
         VertxCatsServerOptions
           .customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.metricsInterceptor(otel))
           .options
       }
       .use: @if(addMetrics) {serverOptions} else {dispatcher} =>

--- a/backend/src/main/twirl/MainIOVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainIOVertxScala3.scala.txt
@@ -22,7 +22,7 @@ object Main extends IOApp:
       .map: d => 
         VertxCatsServerOptions
           .customiseInterceptors(d)
-          .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+          .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
           .options
       }
       .use: @if(addMetrics) {serverOptions} else {dispatcher} =>

--- a/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
@@ -8,7 +8,7 @@ object Main extends OxApp.Simple:
 
   def run(using Ox): Unit =@if(addMetrics) {
     val serverOptions = NettySyncServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
       .options}
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
     val binding = useInScope(NettySyncServer(@if(addMetrics){serverOptions}).port(port).addEndpoints(Endpoints.all).start())(_.stop())

--- a/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainSyncNettyScala3.scala.txt
@@ -1,14 +1,16 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import ox.*
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import ox.*
 import sttp.tapir.server.netty.sync.@if(addMetrics){{NettySyncServer, NettySyncServerOptions}}else{NettySyncServer}
 
 object Main extends OxApp.Simple:
 
   def run(using Ox): Unit =@if(addMetrics) {
+    val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
     val serverOptions = NettySyncServerOptions.customiseInterceptors
-      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.metricsInterceptor(otel))
       .options}
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
     val binding = useInScope(NettySyncServer(@if(addMetrics){serverOptions}).port(port).addEndpoints(Endpoints.all).start())(_.stop())

--- a/backend/src/main/twirl/MainZIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4s.scala.txt
@@ -16,7 +16,7 @@ object Main extends ZIOAppDefault {
     @if(addMetrics) {
     val serverOptions: Http4sServerOptions[Task] =
       Http4sServerOptions.customiseInterceptors[Task]
-        .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
         .options
     val routes = ZHttp4sServerInterpreter(serverOptions).from(Endpoints.all).toRoutes[Any]
     } else {

--- a/backend/src/main/twirl/MainZIOHttp4s.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4s.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import com.comcast.ip4s.{Host, IpLiteralSyntax, Port}
+import com.comcast.ip4s.{Host, IpLiteralSyntax, Port}@if(addMetrics){
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk}
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router@if(addMetrics){
 import sttp.tapir.server.http4s.Http4sServerOptions}
@@ -14,9 +15,10 @@ object Main extends ZIOAppDefault {
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
     @if(addMetrics) {
+    val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
     val serverOptions: Http4sServerOptions[Task] =
       Http4sServerOptions.customiseInterceptors[Task]
-        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.metricsInterceptor(otel))
         .options
     val routes = ZHttp4sServerInterpreter(serverOptions).from(Endpoints.all).toRoutes[Any]
     } else {

--- a/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
@@ -16,7 +16,7 @@ object Main extends ZIOAppDefault:
     @if(addMetrics) {
     val serverOptions: Http4sServerOptions[Task] =
       Http4sServerOptions.customiseInterceptors[Task]
-        .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
         .options
     val routes = ZHttp4sServerInterpreter(serverOptions).from(Endpoints.all).toRoutes[Any]
     } else {

--- a/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOHttp4sScala3.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import com.comcast.ip4s.{Host, Port, port}
+import com.comcast.ip4s.{Host, Port, port}@if(addMetrics){
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk}
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.Router@if(addMetrics){
 import sttp.tapir.server.http4s.Http4sServerOptions}
@@ -14,9 +15,10 @@ object Main extends ZIOAppDefault:
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
     @if(addMetrics) {
+    val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
     val serverOptions: Http4sServerOptions[Task] =
       Http4sServerOptions.customiseInterceptors[Task]
-        .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+        .metricsInterceptor(Endpoints.metricsInterceptor(otel))
         .options
     val routes = ZHttp4sServerInterpreter(serverOptions).from(Endpoints.all).toRoutes[Any]
     } else {

--- a/backend/src/main/twirl/MainZIONetty.scala.txt
+++ b/backend/src/main/twirl/MainZIONetty.scala.txt
@@ -2,7 +2,8 @@
 package @groupId
 
 import zio.{Console, Scope, ZIO, ZIOAppArgs, ZIOAppDefault}
-import sttp.tapir.server.netty.zio.NettyZioServer
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.netty.zio.NettyZioServer
 import sttp.tapir.server.netty.zio.NettyZioServerOptions
 import zio.ExitCode
 
@@ -11,9 +12,10 @@ object Main extends ZIOAppDefault {
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
-    @if(addMetrics){val options = NettyZioServerOptions
+    @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+    val options = NettyZioServerOptions
       .customiseInterceptors[Any]
-      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.metricsInterceptor(otel))
       .options
     }else{val options = NettyZioServerOptions.default[Any]
     }val server = NettyZioServer(options).port(port)

--- a/backend/src/main/twirl/MainZIONetty.scala.txt
+++ b/backend/src/main/twirl/MainZIONetty.scala.txt
@@ -13,7 +13,7 @@ object Main extends ZIOAppDefault {
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
     @if(addMetrics){val options = NettyZioServerOptions
       .customiseInterceptors[Any]
-      .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
       .options
     }else{val options = NettyZioServerOptions.default[Any]
     }val server = NettyZioServer(options).port(port)

--- a/backend/src/main/twirl/MainZIONettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIONettyScala3.scala.txt
@@ -13,7 +13,7 @@ object Main extends ZIOAppDefault:
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
     @if(addMetrics){val options = NettyZioServerOptions
       .customiseInterceptors[Any]
-      .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
       .options
     }else{val options = NettyZioServerOptions.default[Any]
     }val server = NettyZioServer.apply(options).port(port)

--- a/backend/src/main/twirl/MainZIONettyScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIONettyScala3.scala.txt
@@ -2,7 +2,8 @@
 package @groupId
 
 import zio.{Console, Scope, ZIO, ZIOAppArgs, ZIOAppDefault}
-import sttp.tapir.server.netty.zio.NettyZioServer
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.netty.zio.NettyZioServer
 import sttp.tapir.server.netty.zio.NettyZioServerOptions
 import zio.ExitCode
 
@@ -11,9 +12,10 @@ object Main extends ZIOAppDefault:
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
     val port = sys.env.get("HTTP_PORT").flatMap(_.toIntOption).getOrElse(8080)
-    @if(addMetrics){val options = NettyZioServerOptions
+    @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+    val options = NettyZioServerOptions
       .customiseInterceptors[Any]
-      .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+      .metricsInterceptor(Endpoints.metricsInterceptor(otel))
       .options
     }else{val options = NettyZioServerOptions.default[Any]
     }val server = NettyZioServer.apply(options).port(port)

--- a/backend/src/main/twirl/MainZIOVertx.scala.txt
+++ b/backend/src/main/twirl/MainZIOVertx.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import io.vertx.core.Vertx
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import io.vertx.core.Vertx
 import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.zio.@if(addMetrics){{VertxZioServerInterpreter, VertxZioServerOptions}}else{VertxZioServerInterpreter}
 import sttp.tapir.server.vertx.zio.VertxZioServerInterpreter.VertxFutureToRIO
@@ -22,9 +23,10 @@ object Main extends ZIOAppDefault {
       serverStart <- ZIO
         .attempt {
           @if(addMetrics) {
+          val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
           val serverOptions = VertxZioServerOptions
             .customiseInterceptors
-            .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+            .metricsInterceptor(Endpoints.metricsInterceptor(otel))
             .options
           }
           Endpoints.all

--- a/backend/src/main/twirl/MainZIOVertx.scala.txt
+++ b/backend/src/main/twirl/MainZIOVertx.scala.txt
@@ -24,7 +24,7 @@ object Main extends ZIOAppDefault {
           @if(addMetrics) {
           val serverOptions = VertxZioServerOptions
             .customiseInterceptors
-            .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+            .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
             .options
           }
           Endpoints.all

--- a/backend/src/main/twirl/MainZIOVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOVertxScala3.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import io.vertx.core.Vertx
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import io.vertx.core.Vertx
 import io.vertx.ext.web.Router
 import sttp.tapir.server.vertx.zio.@if(addMetrics){{VertxZioServerInterpreter, VertxZioServerOptions}}else{VertxZioServerInterpreter}
 import sttp.tapir.server.vertx.zio.VertxZioServerInterpreter.VertxFutureToRIO
@@ -22,9 +23,10 @@ object Main extends ZIOAppDefault:
       serverStart <- ZIO
         .attempt {
           @if(addMetrics) {
+          val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
           val serverOptions = VertxZioServerOptions
             .customiseInterceptors
-            .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
+            .metricsInterceptor(Endpoints.metricsInterceptor(otel))
             .options
           }
           Endpoints.all

--- a/backend/src/main/twirl/MainZIOVertxScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOVertxScala3.scala.txt
@@ -24,7 +24,7 @@ object Main extends ZIOAppDefault:
           @if(addMetrics) {
           val serverOptions = VertxZioServerOptions
             .customiseInterceptors
-            .metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())
+            .metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())
             .options
           }
           Endpoints.all

--- a/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
@@ -14,7 +14,7 @@ object Main extends ZIOAppDefault {
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
     val serverOptions: ZioHttpServerOptions[Any] =
       ZioHttpServerOptions.customiseInterceptors
-        @if(addMetrics){.metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())}
+        @if(addMetrics){.metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())}
         .options
 
     val app: Routes[Any, Response] = ZioHttpInterpreter(serverOptions).toHttp(Endpoints.all)

--- a/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIO.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
 import zio.{Console, LogLevel, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
 import zio.http.{Response, Routes, Server}
 import zio.logging.LogFormat
@@ -12,9 +13,10 @@ object Main extends ZIOAppDefault {
   override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] = SLF4J.slf4j(LogLevel.Debug, LogFormat.default)
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
-    val serverOptions: ZioHttpServerOptions[Any] =
+    @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+    }val serverOptions: ZioHttpServerOptions[Any] =
       ZioHttpServerOptions.customiseInterceptors
-        @if(addMetrics){.metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())}
+        @if(addMetrics){.metricsInterceptor(Endpoints.metricsInterceptor(otel))}
         .options
 
     val app: Routes[Any, Response] = ZioHttpInterpreter(serverOptions).toHttp(Endpoints.all)

--- a/backend/src/main/twirl/MainZIOhttpZIOScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIOScala3.scala.txt
@@ -1,7 +1,8 @@
 @(groupId: String, addDocumentation: Boolean, addMetrics: Boolean)
 package @groupId
 
-import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
+@if(addMetrics){import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+}import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
 import zio.{Console, LogLevel, Scope, ZIO, ZIOAppArgs, ZIOAppDefault, ZLayer}
 import zio.http.{Response, Routes, Server}
 import zio.logging.LogFormat
@@ -12,9 +13,10 @@ object Main extends ZIOAppDefault:
   override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] = SLF4J.slf4j(LogLevel.Debug, LogFormat.default)
 
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
-    val serverOptions: ZioHttpServerOptions[Any] =
+    @if(addMetrics){val otel = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk
+    }val serverOptions: ZioHttpServerOptions[Any] =
       ZioHttpServerOptions.customiseInterceptors
-        @if(addMetrics){.metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())}
+        @if(addMetrics){.metricsInterceptor(Endpoints.metricsInterceptor(otel))}
         .options
 
     val app: Routes[Any, Response] = ZioHttpInterpreter(serverOptions).toHttp(Endpoints.all)

--- a/backend/src/main/twirl/MainZIOhttpZIOScala3.scala.txt
+++ b/backend/src/main/twirl/MainZIOhttpZIOScala3.scala.txt
@@ -14,7 +14,7 @@ object Main extends ZIOAppDefault:
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
     val serverOptions: ZioHttpServerOptions[Any] =
       ZioHttpServerOptions.customiseInterceptors
-        @if(addMetrics){.metricsInterceptor(Endpoints.prometheusMetrics.metricsInterceptor())}
+        @if(addMetrics){.metricsInterceptor(Endpoints.otelMetrics.metricsInterceptor())}
         .options
 
     val app: Routes[Any, Response] = ZioHttpInterpreter(serverOptions).toHttp(Endpoints.all)

--- a/backend/src/main/twirl/scalaCliSingleFile.scala.txt
+++ b/backend/src/main/twirl/scalaCliSingleFile.scala.txt
@@ -9,7 +9,7 @@ jsonEndpoint: String,
 library: String,
 apiEndpoints: String,
 docEndpoints: String,
-metricsEndpoint: String,
+metricsDefinition: String,
 allEndpoints: String,
 mainContent: String,
 scalaVersionEnum: com.softwaremill.adopttapir.starter.ScalaVersion,
@@ -42,8 +42,8 @@ object Endpoints@if(scalaVersionEnum == com.softwaremill.adopttapir.starter.Scal
 @helloEndpointServer@if(jsonEndpoint.nonEmpty){
 @jsonEndpoint}
 @apiEndpoints@if(docEndpoints.nonEmpty){
-@docEndpoints}@if(metricsEndpoint.nonEmpty){
-@metricsEndpoint}
+@docEndpoints}@if(metricsDefinition.nonEmpty){
+@metricsDefinition}
 @allEndpoints@if(scalaVersionEnum == com.softwaremill.adopttapir.starter.ScalaVersion.Scala2){
 @rightBracket}@if(library.nonEmpty){
 

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -18,7 +18,6 @@ import sttp.client4.{SyncBackend, DefaultSyncBackend, UriContext, asStringAlways
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Properties
-import scala.util.control.NonFatal
 
 object Setup:
   type TestFunction = Integer => IO[Unit]
@@ -97,31 +96,9 @@ class StarterServiceITTest extends BaseTest with ParallelTestExecution:
         }
       )
 
-      val metricsEndpointTest: Option[TestFunction] = Option.when(details.addMetrics)(port =>
-        def runWithRetries(retriesAllowed: Int): IO[Unit] =
-          IO.blocking {
-            val result: String =
-              basicRequest.response(asStringAlways).get(uri"http://localhost:$port/metrics").send(backend).body
-
-            result should (include("# HELP tapir_request_duration_seconds Duration of HTTP requests")
-              and include("# TYPE tapir_request_duration_seconds histogram")
-              and include("# HELP tapir_request_total Total HTTP requests")
-              and include("# TYPE tapir_request_total counter")
-              and include("# HELP tapir_request_active Active HTTP requests")
-              and include("# TYPE tapir_request_active gauge"))
-            info(subTest("metrics"))
-          }.handleErrorWith {
-            // Sometimes the registry is empty right after the server starts
-            case NonFatal(_) if retriesAllowed > 0 => IO.sleep(500.millis) >> runWithRetries(retriesAllowed - 1)
-            case NonFatal(e)                       => IO.raiseError(e)
-          }
-
-        runWithRetries(3)
-      )
-
       // get implementation for a given configuration, compile it, unit & integration test it
       val service = GeneratedServiceUnderTest(new ServiceFactory, details)
-      service.run(List(helloEndpointTest, docsEndpointTest, metricsEndpointTest).flatten)
+      service.run(List(helloEndpointTest, docsEndpointTest).flatten)
     }
   }
 

--- a/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/starter/StarterServiceITTest.scala
@@ -2,7 +2,7 @@ package com.softwaremill.adopttapir.starter
 
 import better.files.{FileExtensions, File as BFile}
 import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Resource}
+import cats.effect.{Deferred, IO, Resource}
 import cats.syntax.all.*
 import com.softwaremill.adopttapir.infrastructure.CorrelationId
 import com.softwaremill.adopttapir.metrics.Metrics
@@ -11,16 +11,21 @@ import com.softwaremill.adopttapir.starter.files.{FilesManager, StorageConfig}
 import com.softwaremill.adopttapir.starter.formatting.GeneratedFilesFormatter
 import com.softwaremill.adopttapir.test.ServiceTimeouts.waitForPortTimeout
 import com.softwaremill.adopttapir.test.ShowHelpers.*
-import com.softwaremill.adopttapir.test.{BaseTest, GeneratedService, ServiceFactory}
+import com.softwaremill.adopttapir.test.{BaseTest, GeneratedService, OtlpMetricsSink, ServiceFactory}
 import org.scalatest.{Assertions, ParallelTestExecution}
-import sttp.client4.{SyncBackend, DefaultSyncBackend, UriContext, asStringAlways, basicRequest}
+import sttp.client4.{DefaultSyncBackend, SyncBackend, UriContext, asStringAlways, basicRequest}
 
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Properties
 
 object Setup:
-  type TestFunction = Integer => IO[Unit]
+  trait TestFunction:
+    def setup: Resource[IO, Map[String, String]] = Resource.pure(Map.empty)
+    def apply(port: Integer): IO[Unit]
+
+  object TestFunction:
+    def apply(fn: Integer => IO[Unit]): TestFunction = (port: Integer) => fn(port)
 
   def fromEnvOrElseAll[A](envKeyString: String, fromEnv: String => A)(elseAll: List[A]): List[A] =
     Properties
@@ -76,47 +81,75 @@ class StarterServiceITTest extends BaseTest with ParallelTestExecution:
       val backend: SyncBackend = DefaultSyncBackend()
 
       // define endpoints integration tests
-      val helloEndpointTest: Option[TestFunction] = Some(port =>
+      val helloEndpointTest: TestFunction = TestFunction(port =>
         IO.blocking {
           val result: String =
             basicRequest.response(asStringAlways).get(uri"http://localhost:$port/hello?name=Frodo").send(backend).body
 
           result shouldBe "Hello Frodo"
-          info(subTest("hello"))
+          info(subTest("hello endpoint"))
         }
       )
 
-      val docsEndpointTest: Option[TestFunction] = Option.when(details.addDocumentation)(port =>
-        IO.blocking {
-          val result: String =
-            basicRequest.response(asStringAlways).get(uri"http://localhost:$port/docs/docs.yaml").send(backend).body
+      val docsEndpointTest: Option[TestFunction] = Option.when(details.addDocumentation)(
+        TestFunction(port =>
+          IO.blocking {
+            val result: String =
+              basicRequest.response(asStringAlways).get(uri"http://localhost:$port/docs/docs.yaml").send(backend).body
 
-          result should include("paths:\n  /hello:")
-          info(subTest("docs"))
+            result should include("paths:\n  /hello:")
+            info(subTest("docs endpoint"))
+          }
+        )
+      )
+
+      val metricsTest: Option[IO[TestFunction]] = Option.when(details.addMetrics)(
+        Deferred[IO, OtlpMetricsSink].map { sink =>
+          new TestFunction:
+            override val setup: Resource[IO, Map[String, String]] =
+              OtlpMetricsSink.resource.evalTap(sink.complete).map(otlpEnv)
+            def apply(port: Integer): IO[Unit] =
+              sink.get.flatMap(_.awaitFirstPush) >> IO(info(subTest("metrics")))
         }
       )
+
+      val tests: IO[List[TestFunction]] =
+        metricsTest.sequence.map(metricsTest => List(Some(helloEndpointTest), docsEndpointTest, metricsTest).flatten)
 
       // get implementation for a given configuration, compile it, unit & integration test it
       val service = GeneratedServiceUnderTest(new ServiceFactory, details)
-      service.run(List(helloEndpointTest, docsEndpointTest).flatten)
+      service.run(tests)
     }
   }
 
-  private def subTest(name: String): String = s"should have $name endpoint available"
+  private def subTest(name: String): String = s"should have $name available"
+
+  private def otlpEnv(sink: OtlpMetricsSink): Map[String, String] = Map(
+    "OTEL_TRACES_EXPORTER" -> "none",
+    "OTEL_LOGS_EXPORTER" -> "none",
+    "OTEL_METRICS_EXPORTER" -> "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL" -> "http/protobuf",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" -> s"http://localhost:${sink.port}/v1/metrics",
+    "OTEL_METRIC_EXPORT_INTERVAL" -> "1000"
+  )
 
 case class GeneratedServiceUnderTest(serviceFactory: ServiceFactory, details: StarterDetails):
   import Setup.*
   import TestTimeouts.waitForTestsTimeout
 
-  def run(tests: List[TestFunction]): Unit =
+  def run(testsIO: IO[List[TestFunction]]): Unit =
     val logger = RunLogger()
-    (for
-      zipFile <- generateZipFile(details, logger)
-      tempDir <- createTempDirectory()
-    yield (zipFile, tempDir))
-      .use { case (zipFile, tempDir) =>
-        unzipFile(zipFile, tempDir, logger) >> spawnService(tempDir, details.projectName)
-          .use(service => getPortFromService(service, logger).flatMap(port => runTests(port, tests, logger)))
+    testsIO
+      .flatMap { tests =>
+        (for
+          zipFile <- generateZipFile(details, logger)
+          tempDir <- createTempDirectory()
+          env <- tests.traverse(_.setup)
+        yield (zipFile, tempDir, env.combineAll))
+          .use { case (zipFile, tempDir, env) =>
+            unzipFile(zipFile, tempDir, logger) >> spawnService(tempDir, details.projectName, env)
+              .use(service => getPortFromService(service, logger).flatMap(port => runTests(port, tests, logger)))
+          }
       }
       .unsafeRunSync()
 
@@ -136,8 +169,8 @@ case class GeneratedServiceUnderTest(serviceFactory: ServiceFactory, details: St
   private def unzipFile(zipFile: BFile, tempDir: BFile, logger: RunLogger): IO[Unit] =
     IO.blocking(zipFile.unzipTo(tempDir)) >> logger.log("* zip file was unzipped")
 
-  private def spawnService(tempDir: BFile, projectName: String): Resource[IO, GeneratedService] =
-    Resource.make(serviceFactory.create(details.builder, tempDir / projectName))(_.close())
+  private def spawnService(tempDir: BFile, projectName: String, env: Map[String, String]): Resource[IO, GeneratedService] =
+    Resource.make(serviceFactory.create(details.builder, tempDir / projectName, env))(_.close())
 
   private def getPortFromService(service: GeneratedService, logger: RunLogger): IO[Integer] =
     for

--- a/backend/src/test/scala/com/softwaremill/adopttapir/test/OtlpMetricsSink.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/test/OtlpMetricsSink.scala
@@ -1,0 +1,31 @@
+package com.softwaremill.adopttapir.test
+
+import cats.effect.{Deferred, IO, Resource}
+import com.comcast.ip4s.*
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.{HttpApp, Method, Response, Status}
+
+trait OtlpMetricsSink:
+  def port: Int
+  def awaitFirstPush: IO[Array[Byte]]
+
+object OtlpMetricsSink:
+  val resource: Resource[IO, OtlpMetricsSink] =
+    for
+      firstPush <- Resource.eval(Deferred[IO, Array[Byte]])
+      app = HttpApp[IO] { req =>
+        if req.method == Method.POST && req.uri.path.renderString == "/v1/metrics" then
+          req.body.compile.to(Array).flatMap { bytes =>
+            firstPush.complete(bytes).attempt.as(Response[IO](Status.Ok))
+          }
+        else IO.pure(Response[IO](Status.NotFound))
+      }
+      server <- EmberServerBuilder
+        .default[IO]
+        .withHost(host"localhost")
+        .withPort(port"0")
+        .withHttpApp(app)
+        .build
+    yield new OtlpMetricsSink:
+      override val port: Int = server.address.getPort
+      override val awaitFirstPush: IO[Array[Byte]] = firstPush.get

--- a/backend/src/test/scala/com/softwaremill/adopttapir/test/ServiceFactory.scala
+++ b/backend/src/test/scala/com/softwaremill/adopttapir/test/ServiceFactory.scala
@@ -68,13 +68,13 @@ abstract class GeneratedService:
     override def toString: String = s"[$timestamp]"
 
 class ServiceFactory:
-  def create(builder: Builder, tempDir: better.files.File): IO[GeneratedService] =
+  def create(builder: Builder, tempDir: better.files.File, env: Map[String, String] = Map.empty): IO[GeneratedService] =
     builder match {
-      case Builder.Sbt      => IO.blocking(SbtService(tempDir))
-      case Builder.ScalaCli => IO.blocking(ScalaCliService(tempDir))
+      case Builder.Sbt      => IO.blocking(SbtService(tempDir, env))
+      case Builder.ScalaCli => IO.blocking(ScalaCliService(tempDir, env))
     }
 
-  private case class SbtService(tempDir: better.files.File) extends GeneratedService:
+  private case class SbtService(tempDir: better.files.File, env: Map[String, String]) extends GeneratedService:
     override protected val portPattern = new Regex("^(?:\\[info\\] )?(?:Go to |Server started at )http://localhost:(\\d+).*")
 
     override protected lazy val process: SubProcess = {
@@ -86,10 +86,10 @@ class ServiceFactory:
         // forward std input to forked process - https://www.scala-sbt.org/1.x/docs/Forking.html#Configuring+Input
         "set run / connectInput := true",
         ";compile ;test ;run"
-      ).spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> "0"), mergeErrIntoOut = true)
+      ).spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> "0") ++ env, mergeErrIntoOut = true)
     }
 
-  private case class ScalaCliService(tempDir: better.files.File) extends GeneratedService:
+  private case class ScalaCliService(tempDir: better.files.File, env: Map[String, String]) extends GeneratedService:
     override protected val portPattern = new Regex("^(?:Go to |Server started at )http://localhost:(\\d+).*")
 
     override protected lazy val process: SubProcess =
@@ -106,4 +106,4 @@ class ServiceFactory:
       )
 
       os.proc("scala-cli", "run" +: scalaFiles)
-        .spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> "0"), mergeErrIntoOut = true)
+        .spawn(cwd = os.Path(tempDir.toJava), env = Map("HTTP_PORT" -> "0") ++ env, mergeErrIntoOut = true)

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ val logbackClassicVersion = "1.5.32"
 val scalaTestVersion = "3.2.19"
 val plokhotnyukJsoniterVersion = "2.38.9"
 val zioTestVersion = "2.0.13"
+val opentelemetryVersion = "1.61.0"
 
 val httpDependencies = Seq(
   "org.http4s" %% "http4s-ember-server" % http4sEmberServerVersion,
@@ -281,6 +282,7 @@ lazy val templateDependencies: Project = project
       "http4sEmberServerVersion" -> http4sEmberServerVersion,
       "zioTestVersion" -> zioTestVersion,
       "scalafmtVersion" -> scalafmtVersion,
+      "opentelemetryVersion" -> opentelemetryVersion,
       "sbtVersion" -> sbtVersion.value
     ),
     buildInfoOptions += BuildInfoOption.ToJson,

--- a/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
+++ b/ui/src/components/ConfigurationForm/ConfigurationForm.component.tsx
@@ -287,7 +287,7 @@ export const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ isEmbedded
               label="Expose endpoint documentation using Swagger UI"
               options={ENDPOINTS_OPTIONS}
             />
-            <FormRadioGroup name="addMetrics" label="Add metrics endpoints" options={ENDPOINTS_OPTIONS} />
+            <FormRadioGroup name="addMetrics" label="Add endpoints metrics" options={ENDPOINTS_OPTIONS} />
           </fieldset>
 
           <div className={cx(classes.actionsContainer, classes.formActionsRow)}>

--- a/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.component.test.tsx
+++ b/ui/src/components/ConfigurationForm/__tests__/ConfigurationForm.component.test.tsx
@@ -43,7 +43,7 @@ describe('ConfigurationForm component', () => {
       ).getByText('yes')
     );
     await user.click(within(screen.getByRole('radiogroup', { name: /Add JSON endpoint using/i })).getByText('circe'));
-    await user.click(within(screen.getByRole('radiogroup', { name: /Add metrics endpoints/i })).getByText('yes'));
+    await user.click(within(screen.getByRole('radiogroup', { name: /Add endpoints metrics/i })).getByText('yes'));
 
     await user.click(screen.getByRole('button', { name: /Generate .zip/i }));
 
@@ -144,7 +144,7 @@ describe('ConfigurationForm component', () => {
       ).getByText('yes')
     );
     await user.click(within(screen.getByRole('radiogroup', { name: /Add JSON endpoint using/i })).getByText('circe'));
-    await user.click(within(screen.getByRole('radiogroup', { name: /Add metrics endpoints/i })).getByText('yes'));
+    await user.click(within(screen.getByRole('radiogroup', { name: /Add endpoints metrics/i })).getByText('yes'));
 
     await user.click(screen.getByRole('button', { name: /Reset/i }));
 


### PR DESCRIPTION
DONE:
* replace prometheus metrics and `/metrics` scrape endpoint with otel metrics and otlp push based exporter
* update integration tests to verify metrics export by spinning up stub collector server that awaits first metrics push