### PR TITLE
Allow agents to use adopt tapir to generate project skeletons

### DIFF
--- a/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/http/HttpApi.scala
@@ -1,12 +1,14 @@
 package com.softwaremill.adopttapir.http
 
+import cats.data.Kleisli
 import cats.effect.{IO, Resource}
 import com.comcast.ip4s.Port
 import com.softwaremill.adopttapir.infrastructure.{CorrelationId, CorrelationIdInterceptor}
 import com.softwaremill.adopttapir.logging.FLogging
 import com.softwaremill.adopttapir.util.ServerEndpoints
-import org.http4s.HttpRoutes
 import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.{Header, HttpRoutes}
+import org.typelevel.ci.CIString
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.*
 import sttp.tapir.files.{FilesOptions, staticResourcesGetServerEndpoint}
@@ -57,7 +59,18 @@ class HttpApi(
     .metricsInterceptor(prometheusMetrics.metricsInterceptor())
     .options
 
-  private lazy val publicRoutes: HttpRoutes[IO] = Http4sServerInterpreter(serverOptions).toRoutes(allPublicEndpoints)
+  private def withHintForLLMs(routes: HttpRoutes[IO]): HttpRoutes[IO] =
+    Kleisli { req =>
+      routes(req).map { resp =>
+        val path = req.uri.path.renderString
+        if path == "/" || path.isEmpty || path == "/index.html" then
+          resp.putHeaders(Header.Raw(CIString("Link"), """</llms.txt>; rel="llms-txt"; type="text/markdown""""))
+        else resp
+      }
+    }
+
+  private lazy val publicRoutes: HttpRoutes[IO] =
+    withHintForLLMs(Http4sServerInterpreter(serverOptions).toRoutes(allPublicEndpoints))
   private lazy val adminRoutes: HttpRoutes[IO] = Http4sServerInterpreter(serverOptions).toRoutes(allAdminEndpoints)
 
   lazy val allPublicEndpoints: List[ServerEndpoint[Any with Fs2Streams[IO], IO]] = {

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
@@ -12,6 +12,7 @@ import fs2.io.file.Files
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.model.HeaderNames
 import sttp.tapir.CodecFormat
+import sttp.tapir.EndpointIO.Example
 
 class StarterApi(http: Http, starterService: StarterService, contentService: ContentService):
 
@@ -24,13 +25,34 @@ class StarterApi(http: Http, starterService: StarterService, contentService: Con
 
   private val starterPath = "starter.zip"
 
+  private val starterRequestJsonBody = jsonBody[StarterRequest]
+    .examples(
+      List(
+        Example[StarterRequest](
+          value = StarterRequest(
+            projectName = "my-http-app",
+            groupId = "com.softwaremill",
+            stack = StackRequest.OxStack,
+            implementation = ServerImplementationRequest.Netty,
+            addDocumentation = true,
+            addMetrics = true,
+            json = JsonImplementationRequest.Circe,
+            scalaVersion = ScalaVersionRequest.Scala3,
+            builder = BuilderRequest.Sbt
+          ),
+          name = "Direct style stack with ox and Netty".some,
+          summary = none
+        )
+      )
+    )
+
   private val starterEndpoint =
     val zippedFileStream = streamBinaryBody(Fs2Streams[IO])(CodecFormat.Zip())
 
     baseEndpoint.post
       .in(starterPath)
-      .in(jsonBody[StarterRequest])
-      .out(zippedFileStream)
+      .in(starterRequestJsonBody)
+      .out(zippedFileStream.description(""))
       .out(header(HeaderNames.AccessControlExposeHeaders, HeaderNames.ContentDisposition))
       .out(header[ContentDispositionValue](HeaderNames.ContentDisposition))
       .out(header[ContentLengthValue](HeaderNames.ContentLength))
@@ -61,8 +83,11 @@ class StarterApi(http: Http, starterService: StarterService, contentService: Con
   private val contentEndpoint =
     baseEndpoint.post
       .in(contentPath)
-      .in(jsonBody[StarterRequest])
+      .in(starterRequestJsonBody)
       .out(jsonBody[List[Node]])
+      .description(
+        "Returns the project that `/starter.zip` would generate, as a JSON file tree (paths and contents) instead of a zip archive. Applies the same validation rules and returns the same error format as `/starter.zip`."
+      )
       .serverLogic[IO] { (request: StarterRequest) =>
         val result: EitherT[IO, Fail, List[Node]] = for
           starterDetailsOrFail <- EitherT(IO.pure(FormValidator.validate(request)))

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
@@ -98,10 +98,11 @@ class StarterApi(http: Http, starterService: StarterService, contentService: Con
     baseEndpoint.post
       .in(starterPath)
       .in(starterRequestJsonBody)
-      .out(zippedFileStream.description(""))
+      .out(zippedFileStream)
       .out(header(HeaderNames.AccessControlExposeHeaders, HeaderNames.ContentDisposition))
       .out(header[ContentDispositionValue](HeaderNames.ContentDisposition))
       .out(header[ContentLengthValue](HeaderNames.ContentLength))
+      .description("Fetches starter template based on provided parameters as a zip archive.")
       .serverLogic[IO] { (request: StarterRequest) =>
         val result: EitherT[IO, Fail, (fs2.Stream[IO, Byte], ContentDispositionValue, ContentLengthValue)] = for
           starterDetailsOrFail <- EitherT(IO.pure(FormValidator.validate(request)))
@@ -132,7 +133,7 @@ class StarterApi(http: Http, starterService: StarterService, contentService: Con
       .in(starterRequestJsonBody)
       .out(jsonBody[List[Node]])
       .description(
-        "Returns the project that `/starter.zip` would generate, as a JSON file tree (paths and contents) instead of a zip archive. Applies the same validation rules and returns the same error format as `/starter.zip`."
+        "Fetches starter template as a JSON file tree instead of a zip archive, useful to preview the template contents."
       )
       .serverLogic[IO] { (request: StarterRequest) =>
         val result: EitherT[IO, Fail, List[Node]] = for

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterApi.scala
@@ -26,6 +26,7 @@ class StarterApi(http: Http, starterService: StarterService, contentService: Con
   private val starterPath = "starter.zip"
 
   private val starterRequestJsonBody = jsonBody[StarterRequest]
+    .description("Parameters defining the stack for the tapir app template")
     .examples(
       List(
         Example[StarterRequest](
@@ -41,6 +42,51 @@ class StarterApi(http: Http, starterService: StarterService, contentService: Con
             builder = BuilderRequest.Sbt
           ),
           name = "Direct style stack with ox and Netty".some,
+          summary = none
+        ),
+        Example[StarterRequest](
+          value = StarterRequest(
+            projectName = "my-http-app",
+            groupId = "com.softwaremill",
+            stack = StackRequest.ZIOStack,
+            implementation = ServerImplementationRequest.ZIOHttp,
+            addDocumentation = true,
+            addMetrics = true,
+            json = JsonImplementationRequest.ZIOJson,
+            scalaVersion = ScalaVersionRequest.Scala3,
+            builder = BuilderRequest.Sbt
+          ),
+          name = "ZIO stack".some,
+          summary = none
+        ),
+        Example[StarterRequest](
+          value = StarterRequest(
+            projectName = "my-http-app",
+            groupId = "com.softwaremill",
+            stack = StackRequest.FutureStack,
+            implementation = ServerImplementationRequest.Pekko,
+            addDocumentation = true,
+            addMetrics = true,
+            json = JsonImplementationRequest.Circe,
+            scalaVersion = ScalaVersionRequest.Scala3,
+            builder = BuilderRequest.Sbt
+          ),
+          name = "Scala Future stack with Pekko".some,
+          summary = none
+        ),
+        Example[StarterRequest](
+          value = StarterRequest(
+            projectName = "my-http-app",
+            groupId = "com.softwaremill",
+            stack = StackRequest.IOStack,
+            implementation = ServerImplementationRequest.Http4s,
+            addDocumentation = true,
+            addMetrics = true,
+            json = JsonImplementationRequest.Circe,
+            scalaVersion = ScalaVersionRequest.Scala3,
+            builder = BuilderRequest.Sbt
+          ),
+          name = "Cats Effect IO stack with http4s".some,
           summary = none
         )
       )

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
@@ -5,16 +5,64 @@ import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 import org.latestbit.circe.adt.codec.*
 import sttp.tapir.Schema
+import sttp.tapir.Schema.annotations.description
 
 case class StarterRequest(
+    @description("The name of the generated project")
     projectName: String,
+    @description("The group id for the generated project, e.g. com.softwaremill")
     groupId: String,
+    @description(
+      """The effect stack for the generated project. Each stack supports a specific set of server implementations:
+        |<ul>
+        |  <li><b>FutureStack</b>: Netty, VertX, Pekko</li>
+        |  <li><b>IOStack</b>: Netty, VertX, Http4s</li>
+        |  <li><b>ZIOStack</b>: Netty, VertX, Http4s, ZIOHttp</li>
+        |  <li><b>OxStack</b>: Netty</li>
+        |</ul>""".stripMargin
+    )
     stack: StackRequest,
+    @description(
+      """The HTTP server implementation to use. Must be compatible with the chosen <b>stack</b>:
+        |<ul>
+        |  <li><b>Netty</b></li>
+        |  <li><b>Http4s</b></li>
+        |  <li><b>ZIOHttp</b></li>
+        |  <li><b>VertX</b></li>
+        |  <li><b>Pekko</b></li>
+        |</ul>""".stripMargin
+    )
     implementation: ServerImplementationRequest,
+    @description("If <b>true</b>, generates OpenAPI documentation with Swagger UI for the endpoints")
     addDocumentation: Boolean,
+    @description("If <b>true</b>, wires in OpenTelemetry metrics for the endpoints with auto configured exporter")
     addMetrics: Boolean,
+    @description(
+      """The JSON library used for request/response body serialization:
+        |<ul>
+        |  <li><b>No</b>: no JSON support</li>
+        |  <li><b>Circe</b></li>
+        |  <li><b>Jsoniter</b></li>
+        |  <li><b>UPickle</b></li>
+        |  <li><b>ZIOJson</b>: ZIOStack only</li>
+        |</ul>""".stripMargin
+    )
     json: JsonImplementationRequest,
+    @description(
+      """The Scala version for the generated project:
+        |<ul>
+        |  <li><b>Scala2</b></li>
+        |  <li><b>Scala3</b></li>
+        |</ul>""".stripMargin
+    )
     scalaVersion: ScalaVersionRequest,
+    @description(
+      """The build tool for the generated project:
+        |<ul>
+        |  <li><b>Sbt</b>: sbt build definition, generates a multi file project with tests</li>
+        |  <li><b>ScalaCli</b>: scala-cli, generates single-file build, without tests</li>
+        |</ul>""".stripMargin
+    )
     builder: BuilderRequest
 ) derives Decoder,
       Encoder.AsObject,

--- a/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
+++ b/backend/src/main/scala/com/softwaremill/adopttapir/starter/api/StarterRequest.scala
@@ -1,68 +1,20 @@
 package com.softwaremill.adopttapir.starter.api
 
 import com.softwaremill.adopttapir.starter.*
-import io.circe.generic.semiauto.*
 import io.circe.{Decoder, Encoder}
 import org.latestbit.circe.adt.codec.*
 import sttp.tapir.Schema
 import sttp.tapir.Schema.annotations.description
 
 case class StarterRequest(
-    @description("The name of the generated project")
     projectName: String,
-    @description("The group id for the generated project, e.g. com.softwaremill")
     groupId: String,
-    @description(
-      """The effect stack for the generated project. Each stack supports a specific set of server implementations:
-        |<ul>
-        |  <li><b>FutureStack</b>: Netty, VertX, Pekko</li>
-        |  <li><b>IOStack</b>: Netty, VertX, Http4s</li>
-        |  <li><b>ZIOStack</b>: Netty, VertX, Http4s, ZIOHttp</li>
-        |  <li><b>OxStack</b>: Netty</li>
-        |</ul>""".stripMargin
-    )
     stack: StackRequest,
-    @description(
-      """The HTTP server implementation to use. Must be compatible with the chosen <b>stack</b>:
-        |<ul>
-        |  <li><b>Netty</b></li>
-        |  <li><b>Http4s</b></li>
-        |  <li><b>ZIOHttp</b></li>
-        |  <li><b>VertX</b></li>
-        |  <li><b>Pekko</b></li>
-        |</ul>""".stripMargin
-    )
     implementation: ServerImplementationRequest,
-    @description("If <b>true</b>, generates OpenAPI documentation with Swagger UI for the endpoints")
     addDocumentation: Boolean,
-    @description("If <b>true</b>, wires in OpenTelemetry metrics for the endpoints with auto configured exporter")
     addMetrics: Boolean,
-    @description(
-      """The JSON library used for request/response body serialization:
-        |<ul>
-        |  <li><b>No</b>: no JSON support</li>
-        |  <li><b>Circe</b></li>
-        |  <li><b>Jsoniter</b></li>
-        |  <li><b>UPickle</b></li>
-        |  <li><b>ZIOJson</b>: ZIOStack only</li>
-        |</ul>""".stripMargin
-    )
     json: JsonImplementationRequest,
-    @description(
-      """The Scala version for the generated project:
-        |<ul>
-        |  <li><b>Scala2</b></li>
-        |  <li><b>Scala3</b></li>
-        |</ul>""".stripMargin
-    )
     scalaVersion: ScalaVersionRequest,
-    @description(
-      """The build tool for the generated project:
-        |<ul>
-        |  <li><b>Sbt</b>: sbt build definition, generates a multi file project with tests</li>
-        |  <li><b>ScalaCli</b>: scala-cli, generates single-file build, without tests</li>
-        |</ul>""".stripMargin
-    )
     builder: BuilderRequest
 ) derives Decoder,
       Encoder.AsObject,

--- a/ui/index.html
+++ b/ui/index.html
@@ -29,6 +29,8 @@
     <meta name="theme-color" content="#55494b" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="llms-txt" href="/llms.txt" type="text/markdown" />
+    <meta name="llms-txt" content="/llms.txt" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui/public/llms.txt
+++ b/ui/public/llms.txt
@@ -1,0 +1,33 @@
+# adopt-tapir
+
+> adopt-tapir generates ready-to-run Scala HTTP service skeletons built on [tapir](https://tapir.softwaremill.com/).
+Tapir provides a programmer-friendly, type-safe API to expose, consume and document HTTP endpoints, using the Scala language.
+Pick an effect stack, server implementation, JSON library, Scala version, and build tool, and get a downloadable project zip.
+
+## Docs
+
+- [OpenAPI Swagger UI documentation](https://adopt-tapir.softwaremill.com/api/v1/docs/): interactive Swagger UI documenting starter zip endpoint, request schema, and supported options.
+- [OpenAPI definition in yaml format](https://adopt-tapir.softwaremill.com/api/v1/docs/docs.yaml): download OpenAPI definition in yaml format.
+
+## Usage
+
+Download a starter zip with curl:
+
+```sh
+curl -X 'POST' \
+  'https://adopt-tapir.softwaremill.com/api/v1/starter.zip' \
+  -H 'accept: application/zip' \
+  -H 'Content-Type: application/json' \
+  -o my-http-app.zip \
+  -d '{
+  "projectName": "my-http-app",
+  "groupId": "com.softwaremill",
+  "stack": "OxStack",
+  "implementation": "Netty",
+  "addDocumentation": true,
+  "addMetrics": true,
+  "json": "Circe",
+  "scalaVersion": "Scala3",
+  "builder": "Sbt"
+}'
+```


### PR DESCRIPTION
DONE:
* More textual OpenAPI description of `StarterRequest` properties with few common stack examples
* Add `llms.txt` file describing the app purpose, including links to Swagger UI and downloadable OpenAPI yaml, based on format https://llmstxt.org/#format